### PR TITLE
Add Circuit Breaker

### DIFF
--- a/API.md
+++ b/API.md
@@ -21,25 +21,26 @@ Creates a new order through the proxy service. In Phase 3, orders are sent to th
 **Endpoint**: `POST /orders`
 
 **Headers**:
+
 - `Content-Type: application/json`
 
 **Request Body**:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `customer_id` | string | Yes | Unique customer identifier |
-| `items` | array | Yes | List of order items |
-| `total_amount` | number | Yes | Total order amount |
-| `delivery_date` | string | Yes | ISO 8601 formatted delivery date |
+| Field           | Type   | Required | Description                      |
+| --------------- | ------ | -------- | -------------------------------- |
+| `customer_id`   | string | Yes      | Unique customer identifier       |
+| `items`         | array  | Yes      | List of order items              |
+| `total_amount`  | number | Yes      | Total order amount               |
+| `delivery_date` | string | Yes      | ISO 8601 formatted delivery date |
 
 **Order Item Structure**:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `product_id` | string | Yes | Product identifier |
-| `quantity` | integer | Yes | Quantity ordered |
-| `unit_price` | number | Yes | Price per unit |
-| `specifications` | object | No | Custom product specifications |
+| Field            | Type    | Required | Description                   |
+| ---------------- | ------- | -------- | ----------------------------- |
+| `product_id`     | string  | Yes      | Product identifier            |
+| `quantity`       | integer | Yes      | Quantity ordered              |
+| `unit_price`     | number  | Yes      | Price per unit                |
+| `specifications` | object  | No       | Custom product specifications |
 
 **Example Request**:
 
@@ -113,6 +114,7 @@ Creates a new order through the proxy service. In Phase 3, orders are sent to th
 **Error Responses**:
 
 - **400 Bad Request**: Invalid request body or missing required fields
+
   ```json
   {
     "success": false,
@@ -137,6 +139,7 @@ Compares all orders between the Order Service and SAP Mock to verify data consis
 **Endpoint**: `GET /compare/orders`
 
 **Response** (200 OK):
+
 ```json
 {
   "timestamp": "2025-06-13T15:30:00Z",
@@ -169,6 +172,7 @@ Compares a specific order between both systems.
 **Endpoint**: `GET /compare/orders/{id}`
 
 **Response** (200 OK):
+
 ```json
 {
   "order_id": "550e8400-e29b-41d4-a716-446655440000",
@@ -205,6 +209,7 @@ Checks the health status of the proxy service.
 **Endpoint**: `GET /health`
 
 **Response** (200 OK):
+
 ```json
 {
   "status": "healthy",
@@ -219,6 +224,7 @@ Checks the health status of all services through the proxy.
 **Endpoint**: `GET /api/health/all`
 
 **Response** (200 OK):
+
 ```json
 {
   "proxy": {
@@ -228,14 +234,14 @@ Checks the health status of all services through the proxy.
     "last_check": "2025-06-14T10:30:00Z"
   },
   "order_service": {
-    "status": "healthy", 
+    "status": "healthy",
     "service": "order_service",
     "response_time": 25,
     "last_check": "2025-06-14T10:30:00Z"
   },
   "sap_mock": {
     "status": "healthy",
-    "service": "sap_mock", 
+    "service": "sap_mock",
     "response_time": 150,
     "last_check": "2025-06-14T10:30:00Z"
   }
@@ -249,9 +255,11 @@ Retrieves all orders from the order service through the proxy.
 **Endpoint**: `GET /orders`
 
 **Headers**:
+
 - `Cache-Control: no-cache, no-store, must-revalidate` (response)
 
 **Response** (200 OK):
+
 ```json
 {
   "success": true,
@@ -278,6 +286,7 @@ Checks the health status of the SAP mock service (internal use).
 **Endpoint**: `GET /health`
 
 **Response** (200 OK):
+
 ```json
 {
   "status": "healthy",
@@ -294,6 +303,7 @@ Retrieves current state and metrics for all circuit breakers.
 **Endpoint**: `GET /metrics/circuit-breakers`
 
 **Response** (200 OK):
+
 ```json
 {
   "circuit_breakers": {
@@ -333,6 +343,7 @@ Retrieves current state and metrics for all circuit breakers.
 ```
 
 **Circuit Breaker States**:
+
 - `closed`: Normal operation, requests pass through
 - `open`: Service failing, requests fail immediately
 - `half-open`: Testing recovery, limited requests allowed
@@ -344,6 +355,7 @@ Resets all circuit breakers to the closed state.
 **Endpoint**: `POST /circuit-breakers/reset`
 
 **Response** (200 OK):
+
 ```json
 {
   "success": true,
@@ -359,9 +371,11 @@ Resets a specific circuit breaker to the closed state.
 **Endpoint**: `POST /circuit-breakers/reset/{name}`
 
 **Path Parameters**:
+
 - `name`: Circuit breaker name (`sap` or `order-service`)
 
 **Response** (200 OK):
+
 ```json
 {
   "success": true,
@@ -389,6 +403,7 @@ Real-time WebSocket connection for receiving live updates about orders, metrics,
 #### Supported Message Types
 
 **1. Order Created Events**:
+
 ```json
 {
   "type": "order_created",
@@ -406,6 +421,7 @@ Real-time WebSocket connection for receiving live updates about orders, metrics,
 ```
 
 **2. Metrics Updates**:
+
 ```json
 {
   "type": "metrics_update",
@@ -426,6 +442,7 @@ Real-time WebSocket connection for receiving live updates about orders, metrics,
 ```
 
 **3. Health Status Updates**:
+
 ```json
 {
   "type": "health_update",
@@ -434,7 +451,7 @@ Real-time WebSocket connection for receiving live updates about orders, metrics,
     "response_time": 15
   },
   "order_service": {
-    "status": "healthy", 
+    "status": "healthy",
     "response_time": 25
   },
   "sap_mock": {
@@ -447,31 +464,31 @@ Real-time WebSocket connection for receiving live updates about orders, metrics,
 #### Client Connection Example (JavaScript)
 
 ```javascript
-const ws = new WebSocket('ws://localhost:8080/ws');
+const ws = new WebSocket("ws://localhost:8080/ws");
 
 ws.onopen = () => {
-  console.log('Connected to real-time updates');
+  console.log("Connected to real-time updates");
 };
 
 ws.onmessage = (event) => {
   const data = JSON.parse(event.data);
-  console.log('Received:', data.type, data);
-  
-  switch(data.type) {
-    case 'order_created':
+  console.log("Received:", data.type, data);
+
+  switch (data.type) {
+    case "order_created":
       updateOrdersList(data.order);
       break;
-    case 'metrics_update':
+    case "metrics_update":
       updateMetrics(data);
       break;
-    case 'health_update':
+    case "health_update":
       updateHealthStatus(data);
       break;
   }
 };
 
 ws.onclose = () => {
-  console.log('WebSocket connection closed');
+  console.log("WebSocket connection closed");
 };
 ```
 
@@ -500,12 +517,14 @@ All errors follow a consistent format:
 ## Logging
 
 The proxy service logs all requests with the following information:
+
 - Request method and path
 - Order ID and customer ID
 - Processing duration
 - Response status
 
 Example log entry:
+
 ```json
 {
   "level": "info",
@@ -545,11 +564,12 @@ In Phase 3, the architecture has evolved to complete event-driven decoupling:
 **Topic**: `order.created`
 
 **Event Payload**:
+
 ```json
 {
   "order_id": "550e8400-e29b-41d4-a716-446655440000",
   "customer_id": "CUST-12345",
-  "total_amount": 259.90,
+  "total_amount": 259.9,
   "created_at": "2025-06-13T10:30:00Z",
   "event_time": "2025-06-13T10:30:02Z"
 }
@@ -560,6 +580,7 @@ In Phase 3, the architecture has evolved to complete event-driven decoupling:
 ### Using cURL
 
 Create an order:
+
 ```bash
 curl -X POST http://localhost:8080/orders \
   -H "Content-Type: application/json" \
@@ -576,26 +597,31 @@ curl -X POST http://localhost:8080/orders \
 ```
 
 Compare all orders:
+
 ```bash
 curl http://localhost:8080/compare/orders | jq .
 ```
 
 Compare specific order:
+
 ```bash
 curl http://localhost:8080/compare/orders/{order-id} | jq .
 ```
 
 List orders from Order Service:
+
 ```bash
 curl http://localhost:8081/orders | jq .
 ```
 
 List orders from SAP Mock:
+
 ```bash
 curl http://localhost:8082/orders | jq .
 ```
 
 Check health:
+
 ```bash
 curl http://localhost:8080/health
 curl http://localhost:8081/health
@@ -603,45 +629,71 @@ curl http://localhost:8082/health
 ```
 
 Check circuit breaker metrics:
+
 ```bash
 curl http://localhost:8080/metrics/circuit-breakers | jq .
 ```
 
 Reset all circuit breakers:
+
 ```bash
 curl -X POST http://localhost:8080/circuit-breakers/reset | jq .
 ```
 
 Reset specific circuit breaker:
+
 ```bash
 curl -X POST http://localhost:8080/circuit-breakers/reset/sap | jq .
 curl -X POST http://localhost:8080/circuit-breakers/reset/order-service | jq .
 ```
 
+### Circuit Breaker Configuration
+
+Configure circuit breaker and HTTP timeout behavior with environment variables:
+
+```bash
+# SAP Circuit Breaker (Legacy System - Conservative settings)
+SAP_CB_MAX_FAILURES=3
+SAP_CB_TIMEOUT_SECONDS=10
+SAP_CB_MAX_REQUESTS=2
+SAP_HTTP_TIMEOUT_SECONDS=10
+
+# Order Service Circuit Breaker (Microservice - More tolerant)
+ORDER_SERVICE_CB_MAX_FAILURES=5
+ORDER_SERVICE_CB_TIMEOUT_SECONDS=15
+ORDER_SERVICE_CB_MAX_REQUESTS=3
+ORDER_SERVICE_HTTP_TIMEOUT_SECONDS=15
+```
+
 ### Using the Test Scripts
 
 **Basic functionality test:**
+
 ```bash
 ./scripts/test-order.sh
 ```
 
 **Data comparison and verification:**
+
 ```bash
 ./scripts/compare-data.sh
 ./scripts/demo-comparison.sh
 ```
 
 **Performance testing:**
+
 ```bash
 ./scripts/performance-benchmark.sh
 ```
 
 **Circuit breaker testing:**
+
 ```bash
 ./scripts/test-circuit-breaker.sh
 ```
 
 **Load testing:**
+
 ```bash
 # Basic load test (50 orders, 10 concurrent)
 ./scripts/load-test.sh
@@ -656,6 +708,7 @@ curl -X POST http://localhost:8080/circuit-breakers/reset/order-service | jq .
 ```
 
 **Available load test scenarios:**
+
 - `light`: 20 orders, 5 concurrent (development)
 - `medium`: 100 orders, 15 concurrent (integration)
 - `heavy`: 500 orders, 25 concurrent (performance)

--- a/API.md
+++ b/API.md
@@ -285,6 +285,97 @@ Checks the health status of the SAP mock service (internal use).
 }
 ```
 
+### Circuit Breaker Management
+
+#### Get Circuit Breaker Metrics
+
+Retrieves current state and metrics for all circuit breakers.
+
+**Endpoint**: `GET /metrics/circuit-breakers`
+
+**Response** (200 OK):
+```json
+{
+  "circuit_breakers": {
+    "sap": {
+      "name": "sap",
+      "state": "closed",
+      "failures": 0,
+      "requests": 0,
+      "total_requests": 45,
+      "total_failures": 2,
+      "total_successes": 43,
+      "state_changes": 1,
+      "max_failures": 3,
+      "timeout_seconds": 10,
+      "max_requests": 2,
+      "last_failure": "2025-06-14T10:15:30Z",
+      "last_state_change": "2025-06-14T10:16:00Z"
+    },
+    "order-service": {
+      "name": "order-service",
+      "state": "open",
+      "failures": 5,
+      "requests": 0,
+      "total_requests": 12,
+      "total_failures": 8,
+      "total_successes": 4,
+      "state_changes": 2,
+      "max_failures": 5,
+      "timeout_seconds": 15,
+      "max_requests": 3,
+      "last_failure": "2025-06-14T10:20:45Z",
+      "last_state_change": "2025-06-14T10:20:50Z"
+    }
+  },
+  "timestamp": "2025-06-14T10:25:00Z"
+}
+```
+
+**Circuit Breaker States**:
+- `closed`: Normal operation, requests pass through
+- `open`: Service failing, requests fail immediately
+- `half-open`: Testing recovery, limited requests allowed
+
+#### Reset All Circuit Breakers
+
+Resets all circuit breakers to the closed state.
+
+**Endpoint**: `POST /circuit-breakers/reset`
+
+**Response** (200 OK):
+```json
+{
+  "success": true,
+  "message": "All circuit breakers reset",
+  "timestamp": "2025-06-14T10:25:00Z"
+}
+```
+
+#### Reset Specific Circuit Breaker
+
+Resets a specific circuit breaker to the closed state.
+
+**Endpoint**: `POST /circuit-breakers/reset/{name}`
+
+**Path Parameters**:
+- `name`: Circuit breaker name (`sap` or `order-service`)
+
+**Response** (200 OK):
+```json
+{
+  "success": true,
+  "message": "Circuit breaker reset",
+  "name": "sap",
+  "timestamp": "2025-06-14T10:25:00Z"
+}
+```
+
+**Error Responses**:
+
+- **400 Bad Request**: Missing circuit breaker name
+- **404 Not Found**: Circuit breaker not found
+
 ### WebSocket Real-Time Updates
 
 Real-time WebSocket connection for receiving live updates about orders, metrics, and health status.
@@ -511,6 +602,22 @@ curl http://localhost:8081/health
 curl http://localhost:8082/health
 ```
 
+Check circuit breaker metrics:
+```bash
+curl http://localhost:8080/metrics/circuit-breakers | jq .
+```
+
+Reset all circuit breakers:
+```bash
+curl -X POST http://localhost:8080/circuit-breakers/reset | jq .
+```
+
+Reset specific circuit breaker:
+```bash
+curl -X POST http://localhost:8080/circuit-breakers/reset/sap | jq .
+curl -X POST http://localhost:8080/circuit-breakers/reset/order-service | jq .
+```
+
 ### Using the Test Scripts
 
 **Basic functionality test:**
@@ -527,6 +634,11 @@ curl http://localhost:8082/health
 **Performance testing:**
 ```bash
 ./scripts/performance-benchmark.sh
+```
+
+**Circuit breaker testing:**
+```bash
+./scripts/test-circuit-breaker.sh
 ```
 
 **Load testing:**

--- a/CIRCUIT-BREAKER.md
+++ b/CIRCUIT-BREAKER.md
@@ -1,0 +1,293 @@
+# Circuit Breaker Pattern Implementation
+
+This document describes the circuit breaker implementation in the strangler pattern demo, providing resilience against service failures and preventing cascading outages.
+
+## Overview
+
+Circuit breakers are implemented to protect external service calls to both SAP and Order Service. When a service fails repeatedly, the circuit breaker "opens" and returns errors immediately instead of waiting for timeouts, providing fast failure and preventing resource exhaustion.
+
+## Architecture
+
+```
+┌─────────────┐    ┌─────────────────┐    ┌─────────────────┐
+│  E-commerce │───▶│     Proxy       │───▶│  Order Service  │
+│   System    │    │    Service      │    │  (Circuit       │
+└─────────────┘    │                 │    │   Protected)    │
+                   │  ┌─────────────┐ │    └─────────────────┘
+                   │  │   Circuit   │ │
+                   │  │   Breaker   │ │    ┌─────────────────┐
+                   │  │   Manager   │ │───▶│   SAP Service   │
+                   │  └─────────────┘ │    │  (Circuit       │
+                   └─────────────────┘    │   Protected)    │
+                                          └─────────────────┘
+```
+
+## Circuit Breaker States
+
+### 1. Closed (Normal Operation)
+- All requests pass through to the target service
+- Failure count is tracked
+- Circuit opens when failure threshold is exceeded
+
+### 2. Open (Service Failing)
+- All requests fail immediately with `ErrCircuitBreakerOpen`
+- No requests are sent to the failing service
+- Prevents resource exhaustion and cascading failures
+- After timeout period, circuit transitions to Half-Open
+
+### 3. Half-Open (Testing Recovery)
+- Limited number of requests are allowed through
+- If requests succeed, circuit closes
+- If requests fail, circuit opens again
+- Allows automatic recovery detection
+
+## Configuration
+
+Circuit breakers are configured via environment variables:
+
+### SAP Circuit Breaker
+```bash
+SAP_CB_MAX_FAILURES=3          # failures before opening circuit
+SAP_CB_TIMEOUT_SECONDS=10      # seconds to wait before testing recovery
+SAP_CB_MAX_REQUESTS=2          # max requests allowed in half-open state
+```
+
+### Order Service Circuit Breaker
+```bash
+ORDER_SERVICE_CB_MAX_FAILURES=5
+ORDER_SERVICE_CB_TIMEOUT_SECONDS=15
+ORDER_SERVICE_CB_MAX_REQUESTS=3
+```
+
+### Default Values
+If environment variables are not set, the following defaults are used:
+
+| Service | Max Failures | Timeout | Max Requests |
+|---------|--------------|---------|--------------|
+| SAP | 3 | 10s | 2 |
+| Order Service | 5 | 15s | 3 |
+
+## Implementation Details
+
+### Core Components
+
+**`internal/circuitbreaker/circuit_breaker.go`**
+- Main circuit breaker implementation
+- State management and transition logic
+- Metrics collection and failure tracking
+
+**`internal/circuitbreaker/manager.go`**
+- Manages multiple circuit breakers
+- Central registry for all circuit breakers
+- Provides factory methods and bulk operations
+
+### Protected Services
+
+**SAP Client (`internal/sap/client.go`)**
+- All HTTP calls wrapped with circuit breaker
+- Methods: `CreateOrder()`, `GetOrders()`, `GetOrder()`
+
+**Order Service Client (`internal/orders/client.go`)**
+- All HTTP calls wrapped with circuit breaker  
+- Methods: `CreateOrder()`, `CreateOrderHistorical()`, `GetOrders()`, `GetOrder()`
+
+### Circuit Breaker Execution
+
+```go
+err := circuitBreaker.Execute(func() error {
+    // Make HTTP request to external service
+    resp, err := httpClient.Do(req)
+    if err != nil {
+        return err  // Will increment failure count
+    }
+    // Process response
+    return nil  // Will reset failure count
+})
+```
+
+## Monitoring and Observability
+
+### Metrics Endpoint
+
+**GET** `/metrics/circuit-breakers`
+
+Returns comprehensive metrics for all circuit breakers:
+
+```json
+{
+  "circuit_breakers": {
+    "sap": {
+      "name": "sap",
+      "state": "closed",
+      "failures": 0,
+      "requests": 0,
+      "total_requests": 45,
+      "total_failures": 2,
+      "total_successes": 43,
+      "state_changes": 1,
+      "max_failures": 3,
+      "timeout_seconds": 10,
+      "max_requests": 2,
+      "last_failure": "2025-06-14T10:15:30Z",
+      "last_state_change": "2025-06-14T10:16:00Z"
+    },
+    "order-service": {
+      // Similar structure
+    }
+  },
+  "timestamp": "2025-06-14T10:25:00Z"
+}
+```
+
+### Key Metrics
+
+- **state**: Current circuit breaker state (closed/open/half-open)
+- **failures**: Current consecutive failure count
+- **total_requests**: Total requests processed
+- **total_failures**: Total failed requests
+- **total_successes**: Total successful requests
+- **state_changes**: Number of state transitions
+- **last_failure**: Timestamp of most recent failure
+- **last_state_change**: Timestamp of most recent state change
+
+### Management Endpoints
+
+**Reset All Circuit Breakers**
+```bash
+curl -X POST http://localhost:8080/circuit-breakers/reset
+```
+
+**Reset Specific Circuit Breaker**
+```bash
+curl -X POST http://localhost:8080/circuit-breakers/reset/sap
+curl -X POST http://localhost:8080/circuit-breakers/reset/order-service
+```
+
+## Testing
+
+### Test Script
+
+Use the provided test script to demonstrate circuit breaker functionality:
+
+```bash
+./scripts/test-circuit-breaker.sh
+```
+
+This script:
+- Shows initial circuit breaker states
+- Creates test orders to demonstrate normal operation
+- Provides instructions for testing failure scenarios
+- Shows circuit breaker metrics and recovery
+
+### Manual Testing
+
+**1. Normal Operation**
+```bash
+# View circuit breaker metrics
+curl http://localhost:8080/metrics/circuit-breakers | jq
+
+# Create order (should succeed)
+curl -X POST http://localhost:8080/orders \
+  -H "Content-Type: application/json" \
+  -d '{"customer_id": "test", "items": [{"product_id": "widget", "quantity": 1, "unit_price": 10}], "total_amount": 10}'
+```
+
+**2. Simulate Service Failure**
+```bash
+# Stop SAP service to trigger circuit breaker
+docker-compose stop sap-mock
+
+# Try to create order (will fail after threshold)
+curl -X POST http://localhost:8080/orders \
+  -H "Content-Type: application/json" \
+  -d '{"customer_id": "test", "items": [{"product_id": "widget", "quantity": 1, "unit_price": 10}], "total_amount": 10}'
+
+# Check circuit breaker state (should show "open")
+curl http://localhost:8080/metrics/circuit-breakers | jq
+```
+
+**3. Test Recovery**
+```bash
+# Restart SAP service
+docker-compose start sap-mock
+
+# Wait for timeout period, then test
+sleep 15
+
+# Try order creation (circuit should test recovery)
+curl -X POST http://localhost:8080/orders \
+  -H "Content-Type: application/json" \
+  -d '{"customer_id": "test", "items": [{"product_id": "widget", "quantity": 1, "unit_price": 10}], "total_amount": 10}'
+
+# Check if circuit closed
+curl http://localhost:8080/metrics/circuit-breakers | jq
+```
+
+## Error Handling
+
+### Circuit Breaker Open Error
+
+When a circuit breaker is open, requests fail immediately with:
+
+```json
+{
+  "success": false,
+  "message": "Failed to create order in SAP",
+  "error": "circuit breaker is open"
+}
+```
+
+### Logging
+
+Circuit breaker events are logged with structured logging:
+
+```json
+{
+  "level": "info",
+  "msg": "Circuit breaker state changed",
+  "circuit_breaker": "sap",
+  "from_state": "closed",
+  "to_state": "open",
+  "timestamp": "2025-06-14T10:15:30Z"
+}
+```
+
+```json
+{
+  "level": "error", 
+  "msg": "Failed to create order in SAP",
+  "order_id": "order-123",
+  "error": "circuit breaker is open",
+  "circuit_breaker_state": "open",
+  "timestamp": "2025-06-14T10:15:31Z"
+}
+```
+
+## Benefits
+
+1. **Fast Failure**: No waiting for timeouts when services are down
+2. **Resource Protection**: Prevents thread/connection pool exhaustion
+3. **Cascading Failure Prevention**: Stops failures from propagating
+4. **Automatic Recovery**: Services resume automatically when healthy
+5. **Observability**: Real-time visibility into service health
+6. **Configurability**: Tune behavior per service requirements
+
+## Best Practices
+
+1. **Set Appropriate Thresholds**: Balance between early detection and false positives
+2. **Monitor Circuit States**: Use metrics to understand service behavior
+3. **Test Recovery Scenarios**: Ensure circuits close when services recover
+4. **Log State Changes**: Track circuit breaker events for debugging
+5. **Graceful Degradation**: Provide fallback responses when circuits are open
+
+## Integration with Strangler Pattern
+
+Circuit breakers enhance the strangler pattern by:
+
+- **Protecting the proxy layer** during migration phases
+- **Preventing legacy system failures** from affecting new services
+- **Enabling safe rollback** if new services fail
+- **Providing visibility** into service health during migration
+- **Supporting gradual cutover** with failure isolation
+
+This implementation ensures that the strangler pattern migration is resilient and can handle service failures gracefully while maintaining system stability.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This project demonstrates how to implement the strangler pattern by building a p
 ✅ **Phase 2 Complete**: Dual-write pattern with new order service, PostgreSQL, and Kafka events  
 ✅ **Phase 3 Complete**: Event-driven architecture with SAP consuming from Kafka  
 ✅ **Dashboard**: Real-time monitoring with WebSocket updates  
-✅ **Data Tools**: Migration and validation CLI tools
+✅ **Data Tools**: Migration and validation CLI tools  
+✅ **Circuit Breaker**: Resilience pattern protecting against service failures
 
 ## Architecture
 
@@ -81,7 +82,8 @@ strangler-demo/
 │   ├── sap/            # SAP client integration
 │   ├── websocket/      # WebSocket hub for real-time updates
 │   ├── migration/      # Data migration utilities
-│   └── comparison/     # Data validation and comparison
+│   ├── comparison/     # Data validation and comparison
+│   └── circuitbreaker/ # Circuit breaker resilience pattern
 ├── pkg/
 │   └── models/         # Shared data models
 ├── scripts/            # Test and demo scripts
@@ -130,6 +132,9 @@ The dashboard provides:
 # Data comparison verification
 ./scripts/compare-data.sh
 
+# Circuit breaker testing
+./scripts/test-circuit-breaker.sh
+
 # Load testing
 ./scripts/load-test.sh
 ```
@@ -170,6 +175,14 @@ The dashboard provides:
 - `order.created` events with full order details
 - Event monitoring via Kafka UI
 - Reliable event consumption with retry logic
+
+### ✅ Circuit Breaker Resilience
+- Protection against cascading failures
+- Fast failure when services are down (no timeouts)
+- Automatic recovery testing and circuit closing
+- Independent circuit breakers for SAP and Order Service
+- Real-time monitoring via `/metrics/circuit-breakers`
+- Configurable thresholds and timeout settings
 
 ### ✅ Data Consistency
 - Real-time consistency verification between systems

--- a/cmd/dlq-monitor/main.go
+++ b/cmd/dlq-monitor/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"syscall"

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -1,0 +1,220 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+type State int
+
+const (
+	StateClosed State = iota
+	StateOpen
+	StateHalfOpen
+)
+
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+var (
+	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
+)
+
+type Config struct {
+	Name            string
+	MaxFailures     int
+	Timeout         time.Duration
+	MaxRequests     int
+	OnStateChange   func(name string, from State, to State)
+}
+
+type CircuitBreaker struct {
+	name         string
+	maxFailures  int
+	timeout      time.Duration
+	maxRequests  int
+	onStateChange func(name string, from State, to State)
+
+	mutex      sync.RWMutex
+	state      State
+	failures   int
+	requests   int
+	lastFailTime time.Time
+	
+	// Metrics
+	totalRequests   int64
+	totalFailures   int64
+	totalSuccesses  int64
+	stateChanges    int64
+	lastStateChange time.Time
+	
+	logger *logrus.Logger
+}
+
+func New(config Config, logger *logrus.Logger) *CircuitBreaker {
+	if config.MaxFailures == 0 {
+		config.MaxFailures = 5
+	}
+	if config.Timeout == 0 {
+		config.Timeout = 30 * time.Second
+	}
+	if config.MaxRequests == 0 {
+		config.MaxRequests = 1
+	}
+
+	return &CircuitBreaker{
+		name:         config.Name,
+		maxFailures:  config.MaxFailures,
+		timeout:      config.Timeout,
+		maxRequests:  config.MaxRequests,
+		onStateChange: config.OnStateChange,
+		state:        StateClosed,
+		logger:       logger,
+	}
+}
+
+func (cb *CircuitBreaker) Execute(fn func() error) error {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	cb.totalRequests++
+	
+	if cb.state == StateOpen {
+		if time.Since(cb.lastFailTime) > cb.timeout {
+			cb.setState(StateHalfOpen)
+			cb.requests = 0
+		} else {
+			cb.logger.WithFields(logrus.Fields{
+				"circuit_breaker": cb.name,
+				"state": cb.state.String(),
+			}).Debug("Circuit breaker is open, rejecting request")
+			return ErrCircuitBreakerOpen
+		}
+	}
+
+	if cb.state == StateHalfOpen && cb.requests >= cb.maxRequests {
+		cb.logger.WithFields(logrus.Fields{
+			"circuit_breaker": cb.name,
+			"state": cb.state.String(),
+			"requests": cb.requests,
+			"max_requests": cb.maxRequests,
+		}).Debug("Circuit breaker half-open max requests reached")
+		return ErrCircuitBreakerOpen
+	}
+
+	cb.requests++
+	
+	// Execute the function
+	cb.mutex.Unlock()
+	err := fn()
+	cb.mutex.Lock()
+
+	if err != nil {
+		cb.onFailure()
+		cb.totalFailures++
+		return err
+	}
+
+	cb.onSuccess()
+	cb.totalSuccesses++
+	return nil
+}
+
+func (cb *CircuitBreaker) onSuccess() {
+	cb.failures = 0
+	
+	if cb.state == StateHalfOpen {
+		cb.setState(StateClosed)
+		cb.requests = 0
+	}
+}
+
+func (cb *CircuitBreaker) onFailure() {
+	cb.failures++
+	cb.lastFailTime = time.Now()
+	
+	if cb.state == StateClosed && cb.failures >= cb.maxFailures {
+		cb.setState(StateOpen)
+		cb.requests = 0
+	} else if cb.state == StateHalfOpen {
+		cb.setState(StateOpen)
+		cb.requests = 0
+	}
+}
+
+func (cb *CircuitBreaker) setState(newState State) {
+	if cb.state == newState {
+		return
+	}
+	
+	oldState := cb.state
+	cb.state = newState
+	cb.stateChanges++
+	cb.lastStateChange = time.Now()
+	
+	cb.logger.WithFields(logrus.Fields{
+		"circuit_breaker": cb.name,
+		"from_state": oldState.String(),
+		"to_state": newState.String(),
+	}).Info("Circuit breaker state changed")
+	
+	if cb.onStateChange != nil {
+		go cb.onStateChange(cb.name, oldState, newState)
+	}
+}
+
+func (cb *CircuitBreaker) State() State {
+	cb.mutex.RLock()
+	defer cb.mutex.RUnlock()
+	return cb.state
+}
+
+func (cb *CircuitBreaker) Metrics() map[string]interface{} {
+	cb.mutex.RLock()
+	defer cb.mutex.RUnlock()
+	
+	return map[string]interface{}{
+		"name":             cb.name,
+		"state":            cb.state.String(),
+		"failures":         cb.failures,
+		"requests":         cb.requests,
+		"total_requests":   cb.totalRequests,
+		"total_failures":   cb.totalFailures,
+		"total_successes":  cb.totalSuccesses,
+		"state_changes":    cb.stateChanges,
+		"max_failures":     cb.maxFailures,
+		"timeout_seconds":  cb.timeout.Seconds(),
+		"max_requests":     cb.maxRequests,
+		"last_failure":     cb.lastFailTime.Format(time.RFC3339),
+		"last_state_change": cb.lastStateChange.Format(time.RFC3339),
+	}
+}
+
+func (cb *CircuitBreaker) Reset() {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+	
+	cb.setState(StateClosed)
+	cb.failures = 0
+	cb.requests = 0
+	cb.lastFailTime = time.Time{}
+}
+
+func (cb *CircuitBreaker) String() string {
+	return fmt.Sprintf("CircuitBreaker(name=%s, state=%s, failures=%d/%d)", 
+		cb.name, cb.state.String(), cb.failures, cb.maxFailures)
+}

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -168,9 +168,11 @@ func (cb *CircuitBreaker) Execute(fn func() error) error {
 		return ErrCircuitBreakerOpen
 	}
 
-	// Only increment totalRequests for requests that will be attempted
+	// Only increment counters for requests that will actually be attempted
 	cb.totalRequests++
-	cb.requests++
+	if cb.state == StateHalfOpen {
+		cb.requests++
+	}
 	cb.mutex.Unlock()
 
 	// Execute function concurrently and wait for result via channel

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -1,0 +1,212 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestExecuteConcurrentAccess(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel) // Reduce noise in tests
+
+	cb := New(Config{
+		Name:        "test",
+		MaxFailures: 3,
+		Timeout:     100 * time.Millisecond,
+		MaxRequests: 2,
+	}, logger)
+
+	// Test concurrent access without race conditions
+	const numGoroutines = 100
+	const numIterations = 10
+
+	var wg sync.WaitGroup
+	errorChan := make(chan error, numGoroutines*numIterations)
+
+	// Function that sometimes fails
+	testFunc := func() error {
+		time.Sleep(1 * time.Millisecond) // Simulate some work
+		if time.Now().UnixNano()%3 == 0 {
+			return errors.New("simulated failure")
+		}
+		return nil
+	}
+
+	// Launch concurrent goroutines
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numIterations; j++ {
+				err := cb.Execute(testFunc)
+				if err != nil {
+					errorChan <- err
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errorChan)
+
+	// Collect results
+	var errorCount int
+	for err := range errorChan {
+		if err != nil {
+			errorCount++
+		}
+	}
+
+	// Verify metrics are consistent
+	metrics := cb.Metrics()
+	totalRequests := metrics["total_requests"].(int64)
+	totalFailures := metrics["total_failures"].(int64)
+	totalSuccesses := metrics["total_successes"].(int64)
+
+	// Basic sanity checks
+	if totalRequests != totalFailures+totalSuccesses {
+		t.Errorf("Inconsistent metrics: total_requests=%d, total_failures=%d, total_successes=%d",
+			totalRequests, totalFailures, totalSuccesses)
+	}
+
+	if totalRequests <= 0 {
+		t.Error("Expected some requests to be processed")
+	}
+
+	t.Logf("Processed %d requests with %d failures and %d successes",
+		totalRequests, totalFailures, totalSuccesses)
+	t.Logf("Circuit breaker final state: %s", cb.State().String())
+}
+
+func TestExecuteChannelBasedExecution(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "channel-test",
+		MaxFailures: 2,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1,
+	}, logger)
+
+	// Test that function execution happens asynchronously but results are properly collected
+	executionOrder := make([]int, 0)
+	var mu sync.Mutex
+
+	slowFunc := func(id int) func() error {
+		return func() error {
+			time.Sleep(10 * time.Millisecond)
+			mu.Lock()
+			executionOrder = append(executionOrder, id)
+			mu.Unlock()
+			return nil
+		}
+	}
+
+	// Execute multiple functions
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			err := cb.Execute(slowFunc(id))
+			if err != nil {
+				t.Errorf("Unexpected error for execution %d: %v", id, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify all executions completed
+	mu.Lock()
+	if len(executionOrder) != 3 {
+		t.Errorf("Expected 3 executions, got %d", len(executionOrder))
+	}
+	mu.Unlock()
+
+	// Verify metrics
+	metrics := cb.Metrics()
+	if metrics["total_requests"].(int64) != 3 {
+		t.Errorf("Expected 3 total requests, got %d", metrics["total_requests"])
+	}
+	if metrics["total_successes"].(int64) != 3 {
+		t.Errorf("Expected 3 successes, got %d", metrics["total_successes"])
+	}
+}
+
+func TestExecuteHalfOpenConcurrency(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "half-open-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 2, // Allow 2 requests in half-open
+	}, logger)
+
+	// Force circuit breaker to open
+	err := cb.Execute(func() error {
+		return errors.New("force failure")
+	})
+	if err == nil {
+		t.Error("Expected failure to open circuit breaker")
+	}
+
+	if cb.State() != StateOpen {
+		t.Errorf("Expected circuit breaker to be open, got %s", cb.State().String())
+	}
+
+	// Wait for timeout to transition to half-open
+	time.Sleep(60 * time.Millisecond)
+
+	// Test concurrent access in half-open state
+	var wg sync.WaitGroup
+	results := make(chan error, 5)
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := cb.Execute(func() error {
+				time.Sleep(5 * time.Millisecond)
+				return nil // Success
+			})
+			results <- err
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Count results
+	var successCount, rejectedCount int
+	for err := range results {
+		if err == ErrCircuitBreakerOpen {
+			rejectedCount++
+		} else if err == nil {
+			successCount++
+		} else {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+
+	// In half-open state with MaxRequests=2, we should have exactly 2 successes
+	// and 3 rejections
+	if successCount != 2 {
+		t.Errorf("Expected 2 successes in half-open state, got %d", successCount)
+	}
+	if rejectedCount != 3 {
+		t.Errorf("Expected 3 rejections in half-open state, got %d", rejectedCount)
+	}
+
+	// Circuit breaker should now be closed after successful executions
+	if cb.State() != StateClosed {
+		t.Errorf("Expected circuit breaker to be closed after successes, got %s", cb.State().String())
+	}
+}

--- a/internal/circuitbreaker/circuit_breaker_test.go
+++ b/internal/circuitbreaker/circuit_breaker_test.go
@@ -210,3 +210,302 @@ func TestExecuteHalfOpenConcurrency(t *testing.T) {
 		t.Errorf("Expected circuit breaker to be closed after successes, got %s", cb.State().String())
 	}
 }
+
+func TestTotalRequestsAccuracy(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "accuracy-test",
+		MaxFailures: 1,
+		Timeout:     100 * time.Millisecond,
+		MaxRequests: 1,
+	}, logger)
+
+	// Force circuit breaker to open by causing a failure
+	err := cb.Execute(func() error {
+		return errors.New("force failure")
+	})
+	if err == nil {
+		t.Error("Expected failure to open circuit breaker")
+	}
+
+	if cb.State() != StateOpen {
+		t.Errorf("Expected circuit breaker to be open, got %s", cb.State().String())
+	}
+
+	// Get initial metrics
+	initialMetrics := cb.Metrics()
+	initialTotalRequests := initialMetrics["total_requests"].(int64)
+
+	// Try to execute while circuit breaker is open (should be rejected)
+	err = cb.Execute(func() error {
+		return nil // This should never execute
+	})
+
+	if err != ErrCircuitBreakerOpen {
+		t.Errorf("Expected ErrCircuitBreakerOpen, got %v", err)
+	}
+
+	// Check if totalRequests was incremented for the rejected request
+	finalMetrics := cb.Metrics()
+	finalTotalRequests := finalMetrics["total_requests"].(int64)
+
+	if finalTotalRequests != initialTotalRequests {
+		t.Errorf("totalRequests was incremented for rejected request: initial=%d, final=%d",
+			initialTotalRequests, finalTotalRequests)
+	}
+
+	t.Logf("Initial total_requests: %d", initialTotalRequests)
+	t.Logf("Final total_requests: %d", finalTotalRequests)
+	t.Logf("Circuit breaker correctly did not count rejected request")
+}
+
+func TestTotalRequestsAccuracyComprehensive(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "comprehensive-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 2, // Allow 2 requests in half-open
+	}, logger)
+
+	// Test 1: Force circuit breaker to open
+	err := cb.Execute(func() error {
+		return errors.New("force failure")
+	})
+	if err == nil {
+		t.Error("Expected failure to open circuit breaker")
+	}
+
+	metrics1 := cb.Metrics()
+	totalRequests1 := metrics1["total_requests"].(int64)
+	t.Logf("After opening circuit breaker: total_requests=%d", totalRequests1)
+
+	// Test 2: Try multiple requests while open (should all be rejected)
+	for i := 0; i < 3; i++ {
+		err = cb.Execute(func() error {
+			t.Error("This function should never execute while circuit breaker is open")
+			return nil
+		})
+		if err != ErrCircuitBreakerOpen {
+			t.Errorf("Expected ErrCircuitBreakerOpen, got %v", err)
+		}
+	}
+
+	metrics2 := cb.Metrics()
+	totalRequests2 := metrics2["total_requests"].(int64)
+	t.Logf("After 3 rejected requests (open): total_requests=%d", totalRequests2)
+
+	if totalRequests2 != totalRequests1 {
+		t.Errorf("totalRequests incremented for open circuit breaker rejections: %d -> %d",
+			totalRequests1, totalRequests2)
+	}
+
+	// Test 3: Wait for timeout to transition to half-open
+	time.Sleep(60 * time.Millisecond)
+
+	// Test 4: Execute exactly MaxRequests (2) successful requests in half-open
+	for i := 0; i < 2; i++ {
+		err = cb.Execute(func() error {
+			return nil // Success
+		})
+		if err != nil {
+			t.Errorf("Expected success in half-open state, got %v", err)
+		}
+	}
+
+	metrics3 := cb.Metrics()
+	totalRequests3 := metrics3["total_requests"].(int64)
+	t.Logf("After 2 successful half-open requests: total_requests=%d", totalRequests3)
+
+	// Should be closed now (standard circuit breaker behavior)
+	if cb.State() != StateClosed {
+		t.Errorf("Expected circuit breaker to be closed, got %s", cb.State().String())
+	}
+
+	// Test 5: Verify that requests in closed state work normally and increment totalRequests
+	err = cb.Execute(func() error {
+		return nil // Success in closed state
+	})
+	if err != nil {
+		t.Errorf("Expected success in closed state, got %v", err)
+	}
+
+	metrics4 := cb.Metrics()
+	totalRequests4 := metrics4["total_requests"].(int64)
+	t.Logf("After request in closed state: total_requests=%d", totalRequests4)
+
+	if totalRequests4 != totalRequests3+1 {
+		t.Errorf("totalRequests should increment for successful requests in closed state: %d -> %d",
+			totalRequests3, totalRequests4)
+	}
+
+	// Test 6: Test concurrent half-open quota rejection behavior
+	// Force open again to test half-open rejection behavior
+	err = cb.Execute(func() error {
+		return errors.New("force failure for concurrent test")
+	})
+	if err == nil {
+		t.Error("Expected failure to open circuit breaker again")
+	}
+
+	// Wait for timeout to go to half-open
+	time.Sleep(60 * time.Millisecond)
+
+	// Get metrics before concurrent test
+	metrics5 := cb.Metrics()
+	totalRequests5 := metrics5["total_requests"].(int64)
+
+	// Launch concurrent requests to test half-open quota behavior
+	// With MaxRequests=2, only 2 should succeed, others should be rejected
+	const numConcurrentRequests = 5
+	var wg sync.WaitGroup
+	results := make(chan error, numConcurrentRequests)
+
+	for i := 0; i < numConcurrentRequests; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			err := cb.Execute(func() error {
+				time.Sleep(10 * time.Millisecond) // Simulate work
+				return nil
+			})
+			results <- err
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Count results
+	var successCount, rejectedCount int
+	for err := range results {
+		if err == ErrCircuitBreakerOpen {
+			rejectedCount++
+		} else if err == nil {
+			successCount++
+		} else {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+
+	metrics6 := cb.Metrics()
+	totalRequests6 := metrics6["total_requests"].(int64)
+	requestsIncrement := totalRequests6 - totalRequests5
+
+	t.Logf("Concurrent test - Success count: %d", successCount)
+	t.Logf("Concurrent test - Rejected count: %d", rejectedCount)
+	t.Logf("Concurrent test - Total requests increment: %d", requestsIncrement)
+	t.Logf("Final total_requests: %d", totalRequests6)
+
+	// Verify that totalRequests only incremented for successful requests
+	if requestsIncrement > int64(successCount) {
+		t.Errorf("totalRequests incremented more than successful requests: increment=%d, successes=%d",
+			requestsIncrement, successCount)
+		t.Error("This indicates rejected requests are being counted in totalRequests")
+	}
+
+	// With MaxRequests=2, we should have at most 2 successes
+	if successCount > 2 {
+		t.Errorf("Expected at most 2 successes with MaxRequests=2, got %d", successCount)
+	}
+
+	// Should have some rejections
+	if rejectedCount == 0 {
+		t.Error("Expected some requests to be rejected due to half-open quota")
+	}
+
+	t.Logf("Final verification: totalRequests correctly incremented only for executed requests")
+}
+
+func TestTotalRequestsRaceCondition(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "race-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1, // Only allow 1 request in half-open
+	}, logger)
+
+	// Force circuit breaker to open
+	err := cb.Execute(func() error {
+		return errors.New("force failure")
+	})
+	if err == nil {
+		t.Error("Expected failure to open circuit breaker")
+	}
+
+	// Wait for timeout to transition to half-open
+	time.Sleep(60 * time.Millisecond)
+
+	// Get initial metrics
+	initialMetrics := cb.Metrics()
+	initialTotalRequests := initialMetrics["total_requests"].(int64)
+	t.Logf("Initial total_requests in half-open: %d", initialTotalRequests)
+
+	// Launch multiple concurrent requests to half-open circuit breaker
+	// Only 1 should succeed (MaxRequests=1), others should be rejected
+	const numConcurrentRequests = 5
+	var wg sync.WaitGroup
+	results := make(chan error, numConcurrentRequests)
+
+	for i := 0; i < numConcurrentRequests; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			err := cb.Execute(func() error {
+				time.Sleep(10 * time.Millisecond) // Simulate work
+				return nil
+			})
+			results <- err
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Count results
+	var successCount, rejectedCount int
+	for err := range results {
+		if err == ErrCircuitBreakerOpen {
+			rejectedCount++
+		} else if err == nil {
+			successCount++
+		} else {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+
+	finalMetrics := cb.Metrics()
+	finalTotalRequests := finalMetrics["total_requests"].(int64)
+	requestsIncrement := finalTotalRequests - initialTotalRequests
+
+	t.Logf("Success count: %d", successCount)
+	t.Logf("Rejected count: %d", rejectedCount)
+	t.Logf("Total requests increment: %d", requestsIncrement)
+	t.Logf("Final total_requests: %d", finalTotalRequests)
+
+	// The issue: totalRequests might be incremented for requests that should be rejected
+	// due to race conditions in the half-open state
+	if requestsIncrement > int64(successCount) {
+		t.Errorf("totalRequests incremented more than successful requests: increment=%d, successes=%d",
+			requestsIncrement, successCount)
+		t.Error("This indicates rejected requests are being counted in totalRequests")
+	}
+
+	// With MaxRequests=1, we should have exactly 1 success and 4 rejections
+	expectedSuccesses := 1
+	expectedRejections := numConcurrentRequests - expectedSuccesses
+
+	if successCount != expectedSuccesses {
+		t.Errorf("Expected %d successes, got %d", expectedSuccesses, successCount)
+	}
+	if rejectedCount != expectedRejections {
+		t.Errorf("Expected %d rejections, got %d", expectedRejections, rejectedCount)
+	}
+}

--- a/internal/circuitbreaker/concurrency_test.go
+++ b/internal/circuitbreaker/concurrency_test.go
@@ -1,0 +1,468 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestConcurrentStateTransitions(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "concurrent-state-test",
+		MaxFailures: 5,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 3,
+	}, logger)
+
+	// Test concurrent failures leading to open state
+	const numGoroutines = 20
+	var wg sync.WaitGroup
+	failureCount := atomic.Int32{}
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := cb.Execute(func() error {
+				failureCount.Add(1)
+				return errors.New("concurrent failure")
+			})
+			if err == nil {
+				t.Error("Expected error")
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Circuit should be open
+	if cb.State() != StateOpen {
+		t.Errorf("Expected StateOpen after concurrent failures, got %s", cb.State())
+	}
+
+	// Verify metrics consistency
+	metrics := cb.Metrics()
+	totalFailures := metrics["total_failures"].(int64)
+	
+	// Not all goroutines may have executed due to circuit opening
+	if totalFailures < int64(cb.maxFailures) {
+		t.Errorf("Expected at least %d failures, got %d", cb.maxFailures, totalFailures)
+	}
+}
+
+func TestConcurrentHalfOpenRequests(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "half-open-concurrent-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 3, // Allow 3 requests in half-open
+	}, logger)
+
+	// Force open
+	cb.Execute(func() error {
+		return errors.New("force open")
+	})
+
+	if cb.State() != StateOpen {
+		t.Fatalf("Expected StateOpen, got %s", cb.State())
+	}
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// Launch concurrent requests
+	const numRequests = 10
+	var wg sync.WaitGroup
+	successCount := atomic.Int32{}
+	rejectedCount := atomic.Int32{}
+	
+	results := make(chan error, numRequests)
+
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			err := cb.Execute(func() error {
+				// Simulate some work
+				time.Sleep(20 * time.Millisecond)
+				return nil
+			})
+			results <- err
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	// Count results
+	for err := range results {
+		if err == nil {
+			successCount.Add(1)
+		} else if err == ErrCircuitBreakerOpen {
+			rejectedCount.Add(1)
+		} else {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+
+	success := successCount.Load()
+	rejected := rejectedCount.Load()
+
+	t.Logf("Half-open concurrent test: %d successes, %d rejected", success, rejected)
+
+	// Should have at most MaxRequests successes
+	if success > 3 {
+		t.Errorf("Expected at most 3 successes in half-open, got %d", success)
+	}
+
+	// Total should be 10
+	if success+rejected != 10 {
+		t.Errorf("Expected 10 total results, got %d", success+rejected)
+	}
+
+	// If we had successes, circuit should be closed
+	if success > 0 && cb.State() != StateClosed {
+		t.Errorf("Expected StateClosed after successful half-open requests, got %s", cb.State())
+	}
+}
+
+func TestRaceConditionProtection(t *testing.T) {
+	// Run with -race flag to detect race conditions
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "race-test",
+		MaxFailures: 10,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 5,
+	}, logger)
+
+	const numGoroutines = 100
+	done := make(chan struct{})
+
+	// Concurrent executions
+	go func() {
+		var wg sync.WaitGroup
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func(id int) {
+				defer wg.Done()
+				for j := 0; j < 10; j++ {
+					cb.Execute(func() error {
+						if id%3 == 0 {
+							return errors.New("error")
+						}
+						return nil
+					})
+				}
+			}(i)
+		}
+		wg.Wait()
+		close(done)
+	}()
+
+	// Concurrent state checks
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = cb.State()
+			}
+		}
+	}()
+
+	// Concurrent metrics reads
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = cb.Metrics()
+			}
+		}
+	}()
+
+	// Concurrent resets
+	go func() {
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				cb.Reset()
+			}
+		}
+	}()
+
+	<-done
+	
+	// Final state check
+	metrics := cb.Metrics()
+	t.Logf("Final metrics after race test: %+v", metrics)
+}
+
+func TestConcurrentStateChangeCallbacks(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	callbackCount := atomic.Int32{}
+	maxConcurrent := atomic.Int32{}
+	currentConcurrent := atomic.Int32{}
+
+	cb := New(Config{
+		Name:        "callback-concurrent-test",
+		MaxFailures: 2,
+		Timeout:     20 * time.Millisecond,
+		MaxRequests: 1,
+		OnStateChange: func(name string, from State, to State) {
+			current := currentConcurrent.Add(1)
+			defer currentConcurrent.Add(-1)
+			
+			// Track max concurrent callbacks
+			for {
+				max := maxConcurrent.Load()
+				if current <= max || maxConcurrent.CompareAndSwap(max, current) {
+					break
+				}
+			}
+			
+			callbackCount.Add(1)
+			// Simulate work
+			time.Sleep(50 * time.Millisecond)
+		},
+	}, logger)
+
+	// Trigger rapid state changes
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Cause failures to trigger state changes
+			for j := 0; j < 2; j++ {
+				cb.Execute(func() error {
+					return errors.New("test")
+				})
+			}
+			time.Sleep(25 * time.Millisecond)
+			// Reset to allow more state changes
+			cb.Reset()
+		}()
+	}
+
+	wg.Wait()
+	
+	// Wait for callbacks to complete
+	time.Sleep(200 * time.Millisecond)
+
+	callbacks := callbackCount.Load()
+	maxConcur := maxConcurrent.Load()
+
+	t.Logf("Total callbacks: %d, Max concurrent: %d", callbacks, maxConcur)
+
+	// Verify callbacks were processed
+	if callbacks == 0 {
+		t.Error("Expected callbacks to be processed")
+	}
+
+	// Verify concurrency was limited (worker pool size is 2)
+	if maxConcur > 2 {
+		t.Errorf("Expected max concurrent callbacks to be <= 2, got %d", maxConcur)
+	}
+
+	cb.Shutdown()
+}
+
+func TestCallbackQueueOverflow(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	processedCallbacks := atomic.Int32{}
+	blockedCallback := make(chan struct{})
+	releaseCallback := make(chan struct{})
+
+	cb := New(Config{
+		Name:        "queue-overflow-test",
+		MaxFailures: 1,
+		Timeout:     10 * time.Millisecond,
+		MaxRequests: 1,
+		OnStateChange: func(name string, from State, to State) {
+			if processedCallbacks.Add(1) == 1 {
+				// First callback blocks until released
+				close(blockedCallback)
+				<-releaseCallback
+			}
+			// Other callbacks process normally
+			time.Sleep(5 * time.Millisecond)
+		},
+	}, logger)
+
+	// Trigger first state change
+	cb.Execute(func() error {
+		return errors.New("test")
+	})
+
+	// Wait for first callback to block
+	<-blockedCallback
+
+	// Trigger many more state changes to overflow queue
+	for i := 0; i < 10; i++ {
+		cb.Reset()
+		cb.Execute(func() error {
+			return errors.New("test")
+		})
+	}
+
+	// Release blocked callback
+	close(releaseCallback)
+
+	// Wait for processing
+	time.Sleep(100 * time.Millisecond)
+
+	processed := processedCallbacks.Load()
+	t.Logf("Processed callbacks: %d", processed)
+
+	// Some callbacks may have been dropped due to queue overflow
+	// This is expected behavior to prevent unbounded memory growth
+	if processed == 0 {
+		t.Error("Expected at least some callbacks to be processed")
+	}
+
+	cb.Shutdown()
+}
+
+func TestConcurrentMetricsAccuracy(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "metrics-accuracy-test",
+		MaxFailures: 100, // High to avoid opening
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 10,
+	}, logger)
+
+	const numGoroutines = 50
+	const opsPerGoroutine = 20
+	
+	expectedSuccesses := atomic.Int64{}
+	expectedFailures := atomic.Int64{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < opsPerGoroutine; j++ {
+				shouldFail := (id+j)%3 == 0
+				err := cb.Execute(func() error {
+					if shouldFail {
+						return errors.New("test failure")
+					}
+					return nil
+				})
+				
+				if err != nil && err != ErrCircuitBreakerOpen {
+					expectedFailures.Add(1)
+				} else if err == nil {
+					expectedSuccesses.Add(1)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify metrics
+	metrics := cb.Metrics()
+	totalRequests := metrics["total_requests"].(int64)
+	totalSuccesses := metrics["total_successes"].(int64)
+	totalFailures := metrics["total_failures"].(int64)
+
+	t.Logf("Metrics - Requests: %d, Successes: %d, Failures: %d", 
+		totalRequests, totalSuccesses, totalFailures)
+	t.Logf("Expected - Successes: %d, Failures: %d",
+		expectedSuccesses.Load(), expectedFailures.Load())
+
+	// Verify consistency
+	if totalRequests != totalSuccesses+totalFailures {
+		t.Errorf("Inconsistent metrics: requests=%d != successes=%d + failures=%d",
+			totalRequests, totalSuccesses, totalFailures)
+	}
+
+	// Verify accuracy (within reasonable bounds due to circuit breaker behavior)
+	if totalSuccesses != expectedSuccesses.Load() {
+		t.Errorf("Success count mismatch: got %d, expected %d",
+			totalSuccesses, expectedSuccesses.Load())
+	}
+
+	if totalFailures != expectedFailures.Load() {
+		t.Errorf("Failure count mismatch: got %d, expected %d",
+			totalFailures, expectedFailures.Load())
+	}
+}
+
+func TestShutdownConcurrency(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	callbackStarted := atomic.Bool{}
+	callbackCompleted := atomic.Bool{}
+
+	cb := New(Config{
+		Name:        "shutdown-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1,
+		OnStateChange: func(name string, from State, to State) {
+			callbackStarted.Store(true)
+			time.Sleep(100 * time.Millisecond)
+			callbackCompleted.Store(true)
+		},
+	}, logger)
+
+	// Trigger state change
+	cb.Execute(func() error {
+		return errors.New("test")
+	})
+
+	// Wait for callback to start
+	for !callbackStarted.Load() {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Shutdown with timeout
+	done := make(chan struct{})
+	go func() {
+		cb.Shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Shutdown completed
+	case <-time.After(6 * time.Second):
+		t.Error("Shutdown took too long")
+	}
+
+	// Verify shutdown behavior
+	if !callbackStarted.Load() {
+		t.Error("Callback should have started")
+	}
+}

--- a/internal/circuitbreaker/config_validation_test.go
+++ b/internal/circuitbreaker/config_validation_test.go
@@ -1,0 +1,400 @@
+package circuitbreaker
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestConfigValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		config         Config
+		expectedName   string
+		expectedMax    int
+		expectedTimeout time.Duration
+		expectedReqs   int
+		shouldPanic    bool
+	}{
+		{
+			name: "valid_config",
+			config: Config{
+				Name:        "test-cb",
+				MaxFailures: 5,
+				Timeout:     30 * time.Second,
+				MaxRequests: 3,
+			},
+			expectedName:    "test-cb",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "empty_name_gets_default",
+			config: Config{
+				Name:        "",
+				MaxFailures: 5,
+				Timeout:     30 * time.Second,
+				MaxRequests: 3,
+			},
+			expectedName:    "unnamed",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "negative_max_failures_gets_default",
+			config: Config{
+				Name:        "test",
+				MaxFailures: -1,
+				Timeout:     30 * time.Second,
+				MaxRequests: 3,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "zero_max_failures_gets_default",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 0,
+				Timeout:     30 * time.Second,
+				MaxRequests: 3,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "negative_timeout_gets_default",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     -1 * time.Second,
+				MaxRequests: 3,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "zero_timeout_gets_default",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     0,
+				MaxRequests: 3,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "timeout_too_small_gets_minimum",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     50 * time.Millisecond,
+				MaxRequests: 3,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 100 * time.Millisecond,
+			expectedReqs:    3,
+		},
+		{
+			name: "negative_max_requests_gets_default",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     30 * time.Second,
+				MaxRequests: -1,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    1,
+		},
+		{
+			name: "zero_max_requests_gets_default",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     30 * time.Second,
+				MaxRequests: 0,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    1,
+		},
+		{
+			name: "max_failures_too_high_gets_capped",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 2000,
+				Timeout:     30 * time.Second,
+				MaxRequests: 3,
+			},
+			expectedName:    "test",
+			expectedMax:     1000,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "timeout_too_high_gets_capped",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     20 * time.Minute,
+				MaxRequests: 3,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 10 * time.Minute,
+			expectedReqs:    3,
+		},
+		{
+			name: "max_requests_too_high_gets_capped",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     30 * time.Second,
+				MaxRequests: 200,
+			},
+			expectedName:    "test",
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    100,
+		},
+		{
+			name: "very_long_name_gets_truncated",
+			config: Config{
+				Name:        strings.Repeat("a", 150),
+				MaxFailures: 5,
+				Timeout:     30 * time.Second,
+				MaxRequests: 3,
+			},
+			expectedName:    strings.Repeat("a", 100),
+			expectedMax:     5,
+			expectedTimeout: 30 * time.Second,
+			expectedReqs:    3,
+		},
+		{
+			name: "nil_logger_panics",
+			config: Config{
+				Name:        "test",
+				MaxFailures: 5,
+				Timeout:     30 * time.Second,
+				MaxRequests: 3,
+			},
+			shouldPanic: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Error("Expected panic for nil logger")
+					}
+				}()
+				_ = New(tt.config, nil)
+				return
+			}
+
+			logger := logrus.New()
+			logger.SetLevel(logrus.ErrorLevel)
+			
+			cb := New(tt.config, logger)
+
+			if cb.name != tt.expectedName {
+				t.Errorf("Expected name %q, got %q", tt.expectedName, cb.name)
+			}
+			if cb.maxFailures != tt.expectedMax {
+				t.Errorf("Expected maxFailures %d, got %d", tt.expectedMax, cb.maxFailures)
+			}
+			if cb.timeout != tt.expectedTimeout {
+				t.Errorf("Expected timeout %v, got %v", tt.expectedTimeout, cb.timeout)
+			}
+			if cb.maxRequests != tt.expectedReqs {
+				t.Errorf("Expected maxRequests %d, got %d", tt.expectedReqs, cb.maxRequests)
+			}
+		})
+	}
+}
+
+func TestConfigWithStateChangeCallback(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	callbackCalled := false
+	config := Config{
+		Name:        "callback-test",
+		MaxFailures: 3,
+		Timeout:     30 * time.Second,
+		MaxRequests: 2,
+		OnStateChange: func(name string, from State, to State) {
+			callbackCalled = true
+		},
+	}
+
+	cb := New(config, logger)
+
+	// Verify callback pool was initialized
+	if cb.callbackPool == nil {
+		t.Error("Expected callback pool to be initialized when OnStateChange is provided")
+	}
+
+	// Verify callback is not called during initialization
+	if callbackCalled {
+		t.Error("Callback should not be called during initialization")
+	}
+
+	cb.Shutdown()
+}
+
+func TestConfigWithoutStateChangeCallback(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	config := Config{
+		Name:        "no-callback-test",
+		MaxFailures: 3,
+		Timeout:     30 * time.Second,
+		MaxRequests: 2,
+		OnStateChange: nil,
+	}
+
+	cb := New(config, logger)
+
+	// Verify callback pool was not initialized
+	if cb.callbackPool != nil {
+		t.Error("Expected callback pool to be nil when OnStateChange is not provided")
+	}
+
+	// Should not panic when state changes without callback
+	cb.setState(StateOpen)
+	cb.setState(StateClosed)
+
+	cb.Shutdown() // Should not panic even without callback pool
+}
+
+func TestConfigCoherenceWarning(t *testing.T) {
+	// Create a logger that captures output
+	var logBuffer strings.Builder
+	logger := logrus.New()
+	logger.SetOutput(&logBuffer)
+	logger.SetLevel(logrus.WarnLevel)
+
+	config := Config{
+		Name:        "coherence-test",
+		MaxFailures: 3,
+		Timeout:     30 * time.Second,
+		MaxRequests: 5, // Greater than MaxFailures
+	}
+
+	_ = New(config, logger)
+
+	output := logBuffer.String()
+	if !strings.Contains(output, "MaxRequests is greater than MaxFailures") {
+		t.Error("Expected warning about MaxRequests > MaxFailures")
+	}
+}
+
+func TestWorkerPoolConfiguration(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	// Test default worker pool size
+	cb1 := New(Config{
+		Name:        "default-workers",
+		MaxFailures: 3,
+		Timeout:     30 * time.Second,
+		MaxRequests: 2,
+		OnStateChange: func(name string, from State, to State) {},
+	}, logger)
+
+	if cb1.callbackPool == nil {
+		t.Fatal("Expected callback pool to be initialized")
+	}
+	if cb1.callbackPool.workers != 2 {
+		t.Errorf("Expected default 2 workers, got %d", cb1.callbackPool.workers)
+	}
+
+	cb1.Shutdown()
+
+	// Test worker pool limits (this requires modifying newCallbackWorkerPool to accept workers parameter)
+	// For now, we'll just verify the pool is created correctly
+	cb2 := New(Config{
+		Name:        "test-workers",
+		MaxFailures: 3,
+		Timeout:     30 * time.Second,
+		MaxRequests: 2,
+		OnStateChange: func(name string, from State, to State) {},
+	}, logger)
+
+	// Verify channel buffer size
+	if cap(cb2.callbackPool.eventChan) != 4 { // workers * 2 = 2 * 2 = 4
+		t.Errorf("Expected event channel capacity 4, got %d", cap(cb2.callbackPool.eventChan))
+	}
+
+	cb2.Shutdown()
+}
+
+func TestAllConfigurationFields(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	var logBuffer strings.Builder
+	logger.SetOutput(&logBuffer)
+
+	config := Config{
+		Name:        "full-config-test",
+		MaxFailures: 5,
+		Timeout:     1 * time.Minute,
+		MaxRequests: 3,
+		OnStateChange: func(name string, from State, to State) {},
+	}
+
+	cb := New(config, logger)
+
+	// Check all fields were set correctly
+	if cb.name != config.Name {
+		t.Errorf("Name mismatch: expected %s, got %s", config.Name, cb.name)
+	}
+	if cb.maxFailures != config.MaxFailures {
+		t.Errorf("MaxFailures mismatch: expected %d, got %d", config.MaxFailures, cb.maxFailures)
+	}
+	if cb.timeout != config.Timeout {
+		t.Errorf("Timeout mismatch: expected %v, got %v", config.Timeout, cb.timeout)
+	}
+	if cb.maxRequests != config.MaxRequests {
+		t.Errorf("MaxRequests mismatch: expected %d, got %d", config.MaxRequests, cb.maxRequests)
+	}
+	if cb.onStateChange == nil {
+		t.Error("OnStateChange callback was not set")
+	}
+	if cb.state != StateClosed {
+		t.Errorf("Initial state should be StateClosed, got %s", cb.state)
+	}
+	if cb.logger != logger {
+		t.Error("Logger was not set correctly")
+	}
+
+	// Verify debug log was written
+	output := logBuffer.String()
+	if !strings.Contains(output, "Circuit breaker created with configuration") {
+		t.Error("Expected debug log message about configuration")
+	}
+
+	cb.Shutdown()
+}

--- a/internal/circuitbreaker/manager.go
+++ b/internal/circuitbreaker/manager.go
@@ -1,0 +1,85 @@
+package circuitbreaker
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Manager struct {
+	breakers map[string]*CircuitBreaker
+	mutex    sync.RWMutex
+	logger   *logrus.Logger
+}
+
+func NewManager(logger *logrus.Logger) *Manager {
+	return &Manager{
+		breakers: make(map[string]*CircuitBreaker),
+		logger:   logger,
+	}
+}
+
+func (m *Manager) GetOrCreate(name string, config Config) *CircuitBreaker {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	
+	if breaker, exists := m.breakers[name]; exists {
+		return breaker
+	}
+	
+	config.Name = name
+	breaker := New(config, m.logger)
+	m.breakers[name] = breaker
+	
+	m.logger.WithFields(logrus.Fields{
+		"circuit_breaker": name,
+		"max_failures": config.MaxFailures,
+		"timeout": config.Timeout.String(),
+		"max_requests": config.MaxRequests,
+	}).Info("Circuit breaker created")
+	
+	return breaker
+}
+
+func (m *Manager) Get(name string) *CircuitBreaker {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	
+	return m.breakers[name]
+}
+
+func (m *Manager) GetAllMetrics() map[string]interface{} {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	
+	metrics := make(map[string]interface{})
+	for name, breaker := range m.breakers {
+		metrics[name] = breaker.Metrics()
+	}
+	
+	return metrics
+}
+
+func (m *Manager) ResetAll() {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	
+	for _, breaker := range m.breakers {
+		breaker.Reset()
+	}
+	
+	m.logger.Info("All circuit breakers reset")
+}
+
+func (m *Manager) Reset(name string) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+	
+	if breaker, exists := m.breakers[name]; exists {
+		breaker.Reset()
+		m.logger.WithField("circuit_breaker", name).Info("Circuit breaker reset")
+		return true
+	}
+	
+	return false
+}

--- a/internal/circuitbreaker/manager_test.go
+++ b/internal/circuitbreaker/manager_test.go
@@ -1,0 +1,176 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestManager(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	manager := NewManager(logger)
+
+	// Test GetOrCreate
+	config1 := Config{
+		MaxFailures: 3,
+		Timeout:     100 * time.Millisecond,
+		MaxRequests: 2,
+	}
+
+	cb1 := manager.GetOrCreate("test-cb-1", config1)
+	if cb1 == nil {
+		t.Fatal("Expected circuit breaker, got nil")
+	}
+
+	// Getting the same circuit breaker should return the same instance
+	cb1Again := manager.GetOrCreate("test-cb-1", config1)
+	if cb1 != cb1Again {
+		t.Error("Expected same circuit breaker instance")
+	}
+
+	// Create another circuit breaker
+	config2 := Config{
+		MaxFailures: 5,
+		Timeout:     200 * time.Millisecond,
+		MaxRequests: 3,
+	}
+
+	cb2 := manager.GetOrCreate("test-cb-2", config2)
+	if cb2 == nil {
+		t.Fatal("Expected circuit breaker, got nil")
+	}
+
+	if cb1 == cb2 {
+		t.Error("Expected different circuit breaker instances")
+	}
+
+	// Test Get
+	cbGet := manager.Get("test-cb-1")
+	if cbGet != cb1 {
+		t.Error("Expected to get cb1")
+	}
+
+	cbGetNil := manager.Get("non-existent")
+	if cbGetNil != nil {
+		t.Error("Expected nil for non-existent circuit breaker")
+	}
+
+	// Test GetAllMetrics
+	metrics := manager.GetAllMetrics()
+	if len(metrics) != 2 {
+		t.Errorf("Expected 2 circuit breakers in metrics, got %d", len(metrics))
+	}
+
+	// Verify metrics contain our circuit breakers
+	foundCb1 := false
+	foundCb2 := false
+	for cbName, m := range metrics {
+		metricsMap := m.(map[string]interface{})
+		name := metricsMap["name"].(string)
+		if cbName == "test-cb-1" && name == "test-cb-1" {
+			foundCb1 = true
+		} else if cbName == "test-cb-2" && name == "test-cb-2" {
+			foundCb2 = true
+		}
+	}
+
+	if !foundCb1 || !foundCb2 {
+		t.Error("Expected to find both circuit breakers in metrics")
+	}
+
+	// Test Reset specific circuit breaker
+	// First cause a failure
+	cb1.Execute(func() error {
+		return errors.New("test failure")
+	})
+
+	metrics1 := cb1.Metrics()
+	if metrics1["failures"].(int) != 1 {
+		t.Error("Expected 1 failure")
+	}
+
+	// Reset it
+	manager.Reset("test-cb-1")
+
+	metrics1After := cb1.Metrics()
+	if metrics1After["failures"].(int) != 0 {
+		t.Error("Expected 0 failures after reset")
+	}
+
+	// Test ResetAll
+	// Cause failures in both
+	cb1.Execute(func() error {
+		return errors.New("test failure")
+	})
+	cb2.Execute(func() error {
+		return errors.New("test failure")
+	})
+
+	// Reset all
+	manager.ResetAll()
+
+	// Verify both are reset
+	metrics1Final := cb1.Metrics()
+	metrics2Final := cb2.Metrics()
+
+	if metrics1Final["failures"].(int) != 0 {
+		t.Error("Expected cb1 failures to be 0 after ResetAll")
+	}
+	if metrics2Final["failures"].(int) != 0 {
+		t.Error("Expected cb2 failures to be 0 after ResetAll")
+	}
+}
+
+func TestManagerConcurrentAccess(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	manager := NewManager(logger)
+
+	// Test concurrent GetOrCreate
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100; i++ {
+			config := Config{
+				MaxFailures: 3,
+				Timeout:     100 * time.Millisecond,
+				MaxRequests: 2,
+			}
+			cb := manager.GetOrCreate("concurrent-test", config)
+			cb.Execute(func() error {
+				return nil
+			})
+		}
+		close(done)
+	}()
+
+	// Concurrent metrics reads
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = manager.GetAllMetrics()
+			}
+		}
+	}()
+
+	// Concurrent resets
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				manager.Reset("concurrent-test")
+			}
+		}
+	}()
+
+	<-done
+}

--- a/internal/circuitbreaker/metrics_test.go
+++ b/internal/circuitbreaker/metrics_test.go
@@ -1,0 +1,497 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestMetricsBasicAccuracy(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "metrics-test",
+		MaxFailures: 10,
+		Timeout:     100 * time.Millisecond,
+		MaxRequests: 5,
+	}, logger)
+
+	// Execute some successful requests
+	for i := 0; i < 5; i++ {
+		err := cb.Execute(func() error {
+			return nil
+		})
+		if err != nil {
+			t.Errorf("Expected success, got %v", err)
+		}
+	}
+
+	// Execute some failed requests
+	for i := 0; i < 3; i++ {
+		err := cb.Execute(func() error {
+			return errors.New("test failure")
+		})
+		if err == nil {
+			t.Error("Expected failure")
+		}
+	}
+
+	metrics := cb.Metrics()
+
+	// Verify basic metrics
+	if metrics["total_requests"].(int64) != 8 {
+		t.Errorf("Expected 8 total requests, got %d", metrics["total_requests"])
+	}
+	if metrics["total_successes"].(int64) != 5 {
+		t.Errorf("Expected 5 successes, got %d", metrics["total_successes"])
+	}
+	if metrics["total_failures"].(int64) != 3 {
+		t.Errorf("Expected 3 failures, got %d", metrics["total_failures"])
+	}
+	if metrics["failures"].(int) != 3 {
+		t.Errorf("Expected current failures to be 3, got %d", metrics["failures"])
+	}
+}
+
+func TestMetricsDoNotCountRejectedRequests(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "rejection-metrics-test",
+		MaxFailures: 1,
+		Timeout:     100 * time.Millisecond,
+		MaxRequests: 2,
+	}, logger)
+
+	// Force circuit to open
+	err := cb.Execute(func() error {
+		return errors.New("force open")
+	})
+	if err == nil {
+		t.Fatal("Expected failure")
+	}
+
+	initialMetrics := cb.Metrics()
+	initialTotal := initialMetrics["total_requests"].(int64)
+
+	// Try to execute while open (should be rejected)
+	for i := 0; i < 5; i++ {
+		err = cb.Execute(func() error {
+			t.Error("This should not execute")
+			return nil
+		})
+		if err != ErrCircuitBreakerOpen {
+			t.Errorf("Expected ErrCircuitBreakerOpen, got %v", err)
+		}
+	}
+
+	// Check metrics didn't increase for rejected requests
+	finalMetrics := cb.Metrics()
+	finalTotal := finalMetrics["total_requests"].(int64)
+
+	if finalTotal != initialTotal {
+		t.Errorf("Total requests increased for rejected requests: %d -> %d", 
+			initialTotal, finalTotal)
+	}
+}
+
+func TestMetricsHalfOpenAccuracy(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "half-open-metrics-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 3,
+	}, logger)
+
+	// Force open
+	cb.Execute(func() error {
+		return errors.New("force open")
+	})
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// Execute requests in half-open state
+	var wg sync.WaitGroup
+	successCount := atomic.Int32{}
+	rejectedCount := atomic.Int32{}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := cb.Execute(func() error {
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			})
+			if err == nil {
+				successCount.Add(1)
+			} else if err == ErrCircuitBreakerOpen {
+				rejectedCount.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	metrics := cb.Metrics()
+	
+	// Total requests should only count the initial failure + successful half-open requests
+	totalRequests := metrics["total_requests"].(int64)
+	totalSuccesses := metrics["total_successes"].(int64)
+	totalFailures := metrics["total_failures"].(int64)
+
+	t.Logf("Metrics: requests=%d, successes=%d, failures=%d", 
+		totalRequests, totalSuccesses, totalFailures)
+	t.Logf("Counts: success=%d, rejected=%d", 
+		successCount.Load(), rejectedCount.Load())
+
+	// Verify only successful requests were counted
+	expectedTotal := int64(1 + successCount.Load()) // 1 initial failure + successes
+	if totalRequests != expectedTotal {
+		t.Errorf("Expected %d total requests, got %d", expectedTotal, totalRequests)
+	}
+
+	// Verify consistency
+	if totalRequests != totalSuccesses+totalFailures {
+		t.Errorf("Inconsistent metrics: %d != %d + %d", 
+			totalRequests, totalSuccesses, totalFailures)
+	}
+}
+
+func TestMetricsStateChangeTracking(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "state-change-metrics-test",
+		MaxFailures: 2,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1,
+	}, logger)
+
+	// Initial state changes should be 0
+	metrics := cb.Metrics()
+	if metrics["state_changes"].(int64) != 0 {
+		t.Errorf("Expected 0 initial state changes, got %d", metrics["state_changes"])
+	}
+
+	// Force state changes
+	// Closed -> Open
+	for i := 0; i < 2; i++ {
+		cb.Execute(func() error {
+			return errors.New("failure")
+		})
+	}
+
+	metrics = cb.Metrics()
+	if metrics["state_changes"].(int64) != 1 {
+		t.Errorf("Expected 1 state change (closed->open), got %d", metrics["state_changes"])
+	}
+
+	// Wait for timeout
+	time.Sleep(60 * time.Millisecond)
+
+	// The next request will transition to half-open and possibly to closed
+	err := cb.Execute(func() error {
+		return nil
+	})
+
+	metrics = cb.Metrics()
+	stateChanges := metrics["state_changes"].(int64)
+	
+	// We should have at least 2 state changes:
+	// 1. Closed -> Open (when failures exceeded)
+	// 2. Open -> Half-Open (when first request after timeout)
+	// 3. Half-Open -> Closed (if the request succeeded)
+	// However, due to timing, we might only see 1 or 2
+	if stateChanges < 1 {
+		t.Errorf("Expected at least 1 state change, got %d", stateChanges)
+	}
+	
+	// If the request succeeded, we should see the circuit closed
+	if err == nil && cb.State() == StateClosed {
+		// We should have seen all 3 transitions
+		if stateChanges < 2 {
+			t.Errorf("Expected at least 2 state changes after successful recovery, got %d", stateChanges)
+		}
+	}
+	
+	t.Logf("State changes: %d, Final state: %s", stateChanges, cb.State())
+
+	// Verify last state change time was updated
+	lastChange := metrics["last_state_change"].(string)
+	if lastChange == "" {
+		t.Error("Expected last_state_change to be set")
+	}
+}
+
+func TestMetricsAllFields(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "complete-metrics-test",
+		MaxFailures: 5,
+		Timeout:     30 * time.Second,
+		MaxRequests: 3,
+	}, logger)
+
+	// Execute to populate some metrics
+	cb.Execute(func() error {
+		return errors.New("test")
+	})
+
+	metrics := cb.Metrics()
+
+	// Verify all expected fields are present
+	expectedFields := []string{
+		"name",
+		"state",
+		"failures",
+		"requests",
+		"total_requests",
+		"total_failures",
+		"total_successes",
+		"state_changes",
+		"max_failures",
+		"timeout_seconds",
+		"max_requests",
+		"last_failure",
+		"last_state_change",
+	}
+
+	for _, field := range expectedFields {
+		if _, exists := metrics[field]; !exists {
+			t.Errorf("Expected field %q in metrics", field)
+		}
+	}
+
+	// Verify field types
+	if _, ok := metrics["name"].(string); !ok {
+		t.Error("Expected 'name' to be string")
+	}
+	if _, ok := metrics["state"].(string); !ok {
+		t.Error("Expected 'state' to be string")
+	}
+	if _, ok := metrics["failures"].(int); !ok {
+		t.Error("Expected 'failures' to be int")
+	}
+	if _, ok := metrics["requests"].(int); !ok {
+		t.Error("Expected 'requests' to be int")
+	}
+	if _, ok := metrics["total_requests"].(int64); !ok {
+		t.Error("Expected 'total_requests' to be int64")
+	}
+	if _, ok := metrics["total_failures"].(int64); !ok {
+		t.Error("Expected 'total_failures' to be int64")
+	}
+	if _, ok := metrics["total_successes"].(int64); !ok {
+		t.Error("Expected 'total_successes' to be int64")
+	}
+	if _, ok := metrics["state_changes"].(int64); !ok {
+		t.Error("Expected 'state_changes' to be int64")
+	}
+	if _, ok := metrics["max_failures"].(int); !ok {
+		t.Error("Expected 'max_failures' to be int")
+	}
+	if _, ok := metrics["timeout_seconds"].(float64); !ok {
+		t.Error("Expected 'timeout_seconds' to be float64")
+	}
+	if _, ok := metrics["max_requests"].(int); !ok {
+		t.Error("Expected 'max_requests' to be int")
+	}
+	if _, ok := metrics["last_failure"].(string); !ok {
+		t.Error("Expected 'last_failure' to be string")
+	}
+	if _, ok := metrics["last_state_change"].(string); !ok {
+		t.Error("Expected 'last_state_change' to be string")
+	}
+}
+
+func TestMetricsThreadSafety(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "thread-safety-test",
+		MaxFailures: 100,
+		Timeout:     100 * time.Millisecond,
+		MaxRequests: 10,
+	}, logger)
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+
+	// Concurrent executions
+	wg.Add(numGoroutines)
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				cb.Execute(func() error {
+					if id%2 == 0 {
+						return nil
+					}
+					return errors.New("error")
+				})
+			}
+		}(i)
+	}
+
+	// Concurrent metrics reads
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	metricsReadCount := 0
+	for {
+		select {
+		case <-done:
+			goto verify
+		default:
+			metrics := cb.Metrics()
+			metricsReadCount++
+			
+			// Just read metrics, don't check consistency during concurrent execution
+			// as values might be in flux
+			_ = metrics["total_requests"].(int64)
+			_ = metrics["total_successes"].(int64)
+			_ = metrics["total_failures"].(int64)
+		}
+	}
+
+verify:
+	t.Logf("Read metrics %d times during concurrent execution", metricsReadCount)
+	
+	finalMetrics := cb.Metrics()
+	totalReqs := finalMetrics["total_requests"].(int64)
+	totalSuccess := finalMetrics["total_successes"].(int64)
+	totalFail := finalMetrics["total_failures"].(int64)
+	
+	t.Logf("Final metrics: requests=%d, successes=%d, failures=%d",
+		totalReqs, totalSuccess, totalFail)
+	
+	if totalReqs != totalSuccess+totalFail {
+		t.Errorf("Final metrics inconsistent: %d != %d + %d",
+			totalReqs, totalSuccess, totalFail)
+	}
+}
+
+func TestMetricsAfterReset(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "reset-metrics-test",
+		MaxFailures: 3,
+		Timeout:     100 * time.Millisecond,
+		MaxRequests: 2,
+	}, logger)
+
+	// Build up some metrics
+	for i := 0; i < 5; i++ {
+		cb.Execute(func() error {
+			if i < 3 {
+				return nil
+			}
+			return errors.New("error")
+		})
+	}
+
+	beforeReset := cb.Metrics()
+	
+	// Reset
+	cb.Reset()
+	
+	afterReset := cb.Metrics()
+
+	// Current counters should be reset
+	if afterReset["failures"].(int) != 0 {
+		t.Errorf("Expected failures to be 0 after reset, got %d", afterReset["failures"])
+	}
+	if afterReset["requests"].(int) != 0 {
+		t.Errorf("Expected requests to be 0 after reset, got %d", afterReset["requests"])
+	}
+	if afterReset["state"].(string) != "closed" {
+		t.Errorf("Expected state to be closed after reset, got %s", afterReset["state"])
+	}
+
+	// Total counters should NOT be reset
+	if afterReset["total_requests"].(int64) != beforeReset["total_requests"].(int64) {
+		t.Error("Total requests should not be reset")
+	}
+	if afterReset["total_successes"].(int64) != beforeReset["total_successes"].(int64) {
+		t.Error("Total successes should not be reset")
+	}
+	if afterReset["total_failures"].(int64) != beforeReset["total_failures"].(int64) {
+		t.Error("Total failures should not be reset")
+	}
+
+	// State changes might increase if the state was not already closed
+	// Reset only calls setState if the current state is not already closed
+	beforeState := beforeReset["state"].(string)
+	afterStateChanges := afterReset["state_changes"].(int64)
+	beforeStateChanges := beforeReset["state_changes"].(int64)
+	
+	if beforeState != "closed" && afterStateChanges == beforeStateChanges {
+		t.Errorf("Expected state_changes to increase after reset from %s state, got %d (was %d)",
+			beforeState, afterStateChanges, beforeStateChanges)
+	}
+}
+
+func TestStringRepresentation(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "string-test",
+		MaxFailures: 5,
+		Timeout:     30 * time.Second,
+		MaxRequests: 2,
+	}, logger)
+
+	// Test initial state
+	str := cb.String()
+	expected := "CircuitBreaker(name=string-test, state=closed, failures=0/5)"
+	if str != expected {
+		t.Errorf("Expected %q, got %q", expected, str)
+	}
+
+	// Add some failures
+	for i := 0; i < 3; i++ {
+		cb.Execute(func() error {
+			return errors.New("test")
+		})
+	}
+
+	str = cb.String()
+	expected = "CircuitBreaker(name=string-test, state=closed, failures=3/5)"
+	if str != expected {
+		t.Errorf("Expected %q, got %q", expected, str)
+	}
+
+	// Force open
+	for i := 0; i < 2; i++ {
+		cb.Execute(func() error {
+			return errors.New("test")
+		})
+	}
+
+	str = cb.String()
+	expected = "CircuitBreaker(name=string-test, state=open, failures=5/5)"
+	if str != expected {
+		t.Errorf("Expected %q, got %q", expected, str)
+	}
+}

--- a/internal/circuitbreaker/state_transitions_test.go
+++ b/internal/circuitbreaker/state_transitions_test.go
@@ -1,0 +1,413 @@
+package circuitbreaker
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestStateTransitions(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	tests := []struct {
+		name         string
+		scenario     func(t *testing.T, cb *CircuitBreaker)
+		expectedEnd  State
+	}{
+		{
+			name: "closed_to_open_after_max_failures",
+			scenario: func(t *testing.T, cb *CircuitBreaker) {
+				// Cause MaxFailures failures
+				for i := 0; i < 3; i++ {
+					err := cb.Execute(func() error {
+						return errors.New("test failure")
+					})
+					if err == nil {
+						t.Error("Expected failure")
+					}
+				}
+			},
+			expectedEnd: StateOpen,
+		},
+		{
+			name: "open_to_half_open_after_timeout",
+			scenario: func(t *testing.T, cb *CircuitBreaker) {
+				// Force open
+				for i := 0; i < 3; i++ {
+					cb.Execute(func() error {
+						return errors.New("test failure")
+					})
+				}
+				
+				// Verify open
+				if cb.State() != StateOpen {
+					t.Fatalf("Expected StateOpen, got %s", cb.State())
+				}
+				
+				// Wait for timeout
+				time.Sleep(110 * time.Millisecond)
+				
+				// Next request should transition to half-open
+				cb.Execute(func() error {
+					return nil
+				})
+			},
+			expectedEnd: StateClosed, // Success in half-open closes it
+		},
+		{
+			name: "half_open_to_closed_on_success",
+			scenario: func(t *testing.T, cb *CircuitBreaker) {
+				// Force open
+				for i := 0; i < 3; i++ {
+					cb.Execute(func() error {
+						return errors.New("test failure")
+					})
+				}
+				
+				// Wait for timeout
+				time.Sleep(110 * time.Millisecond)
+				
+				// Success in half-open should close
+				err := cb.Execute(func() error {
+					return nil
+				})
+				if err != nil {
+					t.Errorf("Expected success, got %v", err)
+				}
+			},
+			expectedEnd: StateClosed,
+		},
+		{
+			name: "half_open_to_open_on_failure",
+			scenario: func(t *testing.T, cb *CircuitBreaker) {
+				// Force open
+				for i := 0; i < 3; i++ {
+					cb.Execute(func() error {
+						return errors.New("test failure")
+					})
+				}
+				
+				// Wait for timeout
+				time.Sleep(110 * time.Millisecond)
+				
+				// Failure in half-open should re-open
+				cb.Execute(func() error {
+					return errors.New("test failure")
+				})
+			},
+			expectedEnd: StateOpen,
+		},
+		{
+			name: "closed_remains_closed_with_successes",
+			scenario: func(t *testing.T, cb *CircuitBreaker) {
+				// All successes should keep it closed
+				for i := 0; i < 10; i++ {
+					err := cb.Execute(func() error {
+						return nil
+					})
+					if err != nil {
+						t.Errorf("Expected success, got %v", err)
+					}
+				}
+			},
+			expectedEnd: StateClosed,
+		},
+		{
+			name: "failures_reset_on_success",
+			scenario: func(t *testing.T, cb *CircuitBreaker) {
+				// Two failures (one less than max)
+				for i := 0; i < 2; i++ {
+					cb.Execute(func() error {
+						return errors.New("test failure")
+					})
+				}
+				
+				// Success should reset failure count
+				err := cb.Execute(func() error {
+					return nil
+				})
+				if err != nil {
+					t.Errorf("Expected success, got %v", err)
+				}
+				
+				// Two more failures should not open (count was reset)
+				for i := 0; i < 2; i++ {
+					cb.Execute(func() error {
+						return errors.New("test failure")
+					})
+				}
+			},
+			expectedEnd: StateClosed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := New(Config{
+				Name:        "test",
+				MaxFailures: 3,
+				Timeout:     100 * time.Millisecond,
+				MaxRequests: 2,
+			}, logger)
+
+			tt.scenario(t, cb)
+
+			if cb.State() != tt.expectedEnd {
+				t.Errorf("Expected final state %s, got %s", tt.expectedEnd, cb.State())
+			}
+		})
+	}
+}
+
+func TestStateChangeCallbacks(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	var stateChanges []struct {
+		from State
+		to   State
+	}
+	var mu sync.Mutex
+
+	cb := New(Config{
+		Name:        "callback-test",
+		MaxFailures: 2,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1,
+		OnStateChange: func(name string, from State, to State) {
+			mu.Lock()
+			stateChanges = append(stateChanges, struct {
+				from State
+				to   State
+			}{from, to})
+			mu.Unlock()
+		},
+	}, logger)
+
+	// Trigger state transitions
+	// 1. Closed -> Open
+	for i := 0; i < 2; i++ {
+		cb.Execute(func() error {
+			return errors.New("test failure")
+		})
+	}
+
+	// 2. Open -> Half-Open (after timeout)
+	time.Sleep(60 * time.Millisecond)
+	
+	// 3. Half-Open -> Closed
+	cb.Execute(func() error {
+		return nil
+	})
+
+	// Wait for callbacks to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify callbacks
+	mu.Lock()
+	defer mu.Unlock()
+
+	// We expect at least one state change (Closed -> Open)
+	// The exact number depends on timing and whether the half-open transition occurs
+	if len(stateChanges) == 0 {
+		t.Fatal("Expected at least one state change")
+	}
+
+	// First change should always be Closed -> Open
+	if len(stateChanges) > 0 {
+		first := stateChanges[0]
+		if first.from != StateClosed || first.to != StateOpen {
+			t.Errorf("First state change: expected closed->open, got %s->%s",
+				first.from, first.to)
+		}
+	}
+
+	t.Logf("Recorded %d state changes", len(stateChanges))
+
+	// Shutdown and verify no more callbacks
+	cb.Shutdown()
+}
+
+func TestStateChangeCallbackPanic(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	panicCount := 0
+	var mu sync.Mutex
+
+	cb := New(Config{
+		Name:        "panic-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1,
+		OnStateChange: func(name string, from State, to State) {
+			mu.Lock()
+			panicCount++
+			mu.Unlock()
+			panic("test panic")
+		},
+	}, logger)
+
+	// Trigger state change (should not crash)
+	cb.Execute(func() error {
+		return errors.New("test failure")
+	})
+
+	// Wait for callback
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify state changed despite panic
+	if cb.State() != StateOpen {
+		t.Errorf("Expected StateOpen after failure, got %s", cb.State())
+	}
+
+	mu.Lock()
+	if panicCount == 0 {
+		t.Error("Expected callback to be called even though it panics")
+	}
+	mu.Unlock()
+
+	cb.Shutdown()
+}
+
+func TestStateChangeCallbackTimeout(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	callbackStarted := make(chan struct{})
+	callbackCompleted := atomic.Bool{}
+
+	cb := New(Config{
+		Name:        "timeout-test",
+		MaxFailures: 1,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1,
+		OnStateChange: func(name string, from State, to State) {
+			close(callbackStarted)
+			// Simulate slow callback that exceeds 5s timeout
+			time.Sleep(6 * time.Second)
+			callbackCompleted.Store(true)
+		},
+	}, logger)
+
+	// Trigger state change
+	cb.Execute(func() error {
+		return errors.New("test failure")
+	})
+
+	// Wait for callback to start
+	<-callbackStarted
+
+	// Wait for timeout period
+	time.Sleep(5500 * time.Millisecond)
+
+	// Callback should have timed out
+	if callbackCompleted.Load() {
+		t.Error("Expected callback to timeout, but it completed")
+	}
+
+	cb.Shutdown()
+}
+
+func TestReset(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	cb := New(Config{
+		Name:        "reset-test",
+		MaxFailures: 2,
+		Timeout:     50 * time.Millisecond,
+		MaxRequests: 1,
+	}, logger)
+
+	// Force circuit breaker to open
+	for i := 0; i < 2; i++ {
+		cb.Execute(func() error {
+			return errors.New("test failure")
+		})
+	}
+
+	if cb.State() != StateOpen {
+		t.Fatalf("Expected StateOpen, got %s", cb.State())
+	}
+
+	// Reset
+	cb.Reset()
+
+	// Verify reset
+	if cb.State() != StateClosed {
+		t.Errorf("Expected StateClosed after reset, got %s", cb.State())
+	}
+
+	metrics := cb.Metrics()
+	if metrics["failures"].(int) != 0 {
+		t.Errorf("Expected failures to be 0 after reset, got %d", metrics["failures"])
+	}
+	if metrics["requests"].(int) != 0 {
+		t.Errorf("Expected requests to be 0 after reset, got %d", metrics["requests"])
+	}
+
+	// Verify circuit breaker works normally after reset
+	err := cb.Execute(func() error {
+		return nil
+	})
+	if err != nil {
+		t.Errorf("Expected success after reset, got %v", err)
+	}
+}
+
+func TestMultipleStateChangeCallbacks(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+
+	// Test that multiple state changes are handled correctly by worker pool
+	callbackCount := atomic.Int32{}
+	
+	cb := New(Config{
+		Name:        "multi-callback-test",
+		MaxFailures: 1,
+		Timeout:     20 * time.Millisecond,
+		MaxRequests: 1,
+		OnStateChange: func(name string, from State, to State) {
+			callbackCount.Add(1)
+			// Simulate some work
+			time.Sleep(10 * time.Millisecond)
+		},
+	}, logger)
+
+	// Rapid state changes
+	for i := 0; i < 5; i++ {
+		// Open circuit
+		cb.Execute(func() error {
+			return errors.New("test failure")
+		})
+		
+		// Wait for timeout
+		time.Sleep(25 * time.Millisecond)
+		
+		// Close circuit
+		cb.Execute(func() error {
+			return nil
+		})
+		
+		// Reset for next iteration
+		cb.Reset()
+	}
+
+	// Wait for all callbacks
+	time.Sleep(200 * time.Millisecond)
+
+	count := callbackCount.Load()
+	if count == 0 {
+		t.Error("Expected callbacks to be processed")
+	}
+
+	t.Logf("Processed %d callbacks", count)
+	
+	cb.Shutdown()
+}

--- a/internal/orders/client.go
+++ b/internal/orders/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/jogardn/strangler-demo/internal/circuitbreaker"
@@ -20,16 +22,16 @@ type OrderServiceClient struct {
 }
 
 func NewOrderServiceClient(baseURL string, logger *logrus.Logger, cbManager *circuitbreaker.Manager) *OrderServiceClient {
-	cb := cbManager.GetOrCreate("order-service", circuitbreaker.Config{
-		MaxFailures: 5,
-		Timeout:     15 * time.Second,
-		MaxRequests: 3,
-	})
+	cb := cbManager.Get("order-service")
+	
+	// HTTP timeout should be shorter than circuit breaker timeout for proper coordination
+	// Use 80% of circuit breaker timeout, with a minimum of 5 seconds
+	httpTimeout := getHTTPTimeout("ORDER_SERVICE_HTTP_TIMEOUT_SECONDS", "12", logger)
 	
 	return &OrderServiceClient{
 		baseURL: baseURL,
 		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: httpTimeout,
 		},
 		logger:         logger,
 		circuitBreaker: cb,
@@ -234,4 +236,43 @@ func (c *OrderServiceClient) GetOrder(orderID string) (*models.Order, error) {
 	}
 
 	return order, nil
+}
+
+func getHTTPTimeout(envVar, defaultValue string, logger *logrus.Logger) time.Duration {
+	value := os.Getenv(envVar)
+	if value == "" {
+		value = defaultValue
+	}
+	
+	seconds, err := strconv.Atoi(value)
+	if err != nil || seconds <= 0 {
+		logger.WithFields(logrus.Fields{
+			"env_var": envVar,
+			"value": value,
+			"default": defaultValue,
+			"error": err,
+		}).Warn("Invalid HTTP timeout value, using default")
+		
+		defaultSeconds, defaultErr := strconv.Atoi(defaultValue)
+		if defaultErr != nil || defaultSeconds <= 0 {
+			logger.WithFields(logrus.Fields{
+				"env_var": envVar,
+				"default": defaultValue,
+			}).Error("Invalid default HTTP timeout, using 5 seconds")
+			return 5 * time.Second
+		}
+		return time.Duration(defaultSeconds) * time.Second
+	}
+	
+	// Cap at reasonable maximum
+	if seconds > 300 { // 5 minutes
+		logger.WithFields(logrus.Fields{
+			"env_var": envVar,
+			"value": seconds,
+			"max_allowed": 300,
+		}).Warn("HTTP timeout too high, capping at 5 minutes")
+		seconds = 300
+	}
+	
+	return time.Duration(seconds) * time.Second
 }

--- a/internal/orders/client.go
+++ b/internal/orders/client.go
@@ -7,163 +7,231 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jogardn/strangler-demo/internal/circuitbreaker"
 	"github.com/jogardn/strangler-demo/pkg/models"
 	"github.com/sirupsen/logrus"
 )
 
 type OrderServiceClient struct {
-	baseURL    string
-	httpClient *http.Client
-	logger     *logrus.Logger
+	baseURL        string
+	httpClient     *http.Client
+	logger         *logrus.Logger
+	circuitBreaker *circuitbreaker.CircuitBreaker
 }
 
-func NewOrderServiceClient(baseURL string, logger *logrus.Logger) *OrderServiceClient {
+func NewOrderServiceClient(baseURL string, logger *logrus.Logger, cbManager *circuitbreaker.Manager) *OrderServiceClient {
+	cb := cbManager.GetOrCreate("order-service", circuitbreaker.Config{
+		MaxFailures: 5,
+		Timeout:     15 * time.Second,
+		MaxRequests: 3,
+	})
+	
 	return &OrderServiceClient{
 		baseURL: baseURL,
 		httpClient: &http.Client{
 			Timeout: 10 * time.Second,
 		},
-		logger: logger,
+		logger:         logger,
+		circuitBreaker: cb,
 	}
 }
 
 func (c *OrderServiceClient) CreateOrder(order *models.Order) (*models.OrderResponse, error) {
 	c.logger.WithField("order_id", order.ID).Info("Sending order to order service")
 	
-	jsonData, err := json.Marshal(order)
+	var orderResp *models.OrderResponse
+	err := c.circuitBreaker.Execute(func() error {
+		jsonData, err := json.Marshal(order)
+		if err != nil {
+			return fmt.Errorf("failed to marshal order: %w", err)
+		}
+
+		req, err := http.NewRequest("POST", c.baseURL+"/orders", bytes.NewBuffer(jsonData))
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to send request to order service: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var respData models.OrderResponse
+		if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+			return fmt.Errorf("failed to decode order service response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+			return fmt.Errorf("order service returned error status: %d", resp.StatusCode)
+		}
+
+		orderResp = &respData
+		c.logger.WithFields(logrus.Fields{
+			"order_id": order.ID,
+			"status":   resp.StatusCode,
+			"success":  respData.Success,
+		}).Info("Received response from order service")
+
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal order: %w", err)
+		c.logger.WithFields(logrus.Fields{
+			"order_id": order.ID,
+			"error": err.Error(),
+			"circuit_breaker_state": c.circuitBreaker.State().String(),
+		}).Error("Failed to create order in order service")
+		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", c.baseURL+"/orders", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request to order service: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var orderResp models.OrderResponse
-	if err := json.NewDecoder(resp.Body).Decode(&orderResp); err != nil {
-		return nil, fmt.Errorf("failed to decode order service response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("order service returned error status: %d", resp.StatusCode)
-	}
-
-	c.logger.WithFields(logrus.Fields{
-		"order_id": order.ID,
-		"status":   resp.StatusCode,
-		"success":  orderResp.Success,
-	}).Info("Received response from order service")
-
-	return &orderResp, nil
+	return orderResp, nil
 }
 
 func (c *OrderServiceClient) CreateOrderHistorical(order *models.Order) (*models.OrderResponse, error) {
 	c.logger.WithField("order_id", order.ID).Info("Sending historical order to order service")
 	
-	jsonData, err := json.Marshal(order)
+	var orderResp *models.OrderResponse
+	err := c.circuitBreaker.Execute(func() error {
+		jsonData, err := json.Marshal(order)
+		if err != nil {
+			return fmt.Errorf("failed to marshal historical order: %w", err)
+		}
+
+		req, err := http.NewRequest("POST", c.baseURL+"/orders/historical", bytes.NewBuffer(jsonData))
+		if err != nil {
+			return fmt.Errorf("failed to create historical order request: %w", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to send historical order request to order service: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var respData models.OrderResponse
+		if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+			return fmt.Errorf("failed to decode historical order service response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+			return fmt.Errorf("order service returned error status for historical order: %d", resp.StatusCode)
+		}
+
+		orderResp = &respData
+		c.logger.WithFields(logrus.Fields{
+			"order_id": order.ID,
+			"status":   resp.StatusCode,
+			"success":  respData.Success,
+		}).Info("Historical order created in order service")
+
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal historical order: %w", err)
+		c.logger.WithFields(logrus.Fields{
+			"order_id": order.ID,
+			"error": err.Error(),
+			"circuit_breaker_state": c.circuitBreaker.State().String(),
+		}).Error("Failed to create historical order in order service")
+		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", c.baseURL+"/orders/historical", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create historical order request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send historical order request to order service: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var orderResp models.OrderResponse
-	if err := json.NewDecoder(resp.Body).Decode(&orderResp); err != nil {
-		return nil, fmt.Errorf("failed to decode historical order service response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("order service returned error status for historical order: %d", resp.StatusCode)
-	}
-
-	c.logger.WithFields(logrus.Fields{
-		"order_id": order.ID,
-		"status":   resp.StatusCode,
-		"success":  orderResp.Success,
-	}).Info("Historical order created in order service")
-
-	return &orderResp, nil
+	return orderResp, nil
 }
 
 func (c *OrderServiceClient) GetOrders() ([]models.Order, error) {
 	c.logger.Info("Fetching orders from order service")
 	
-	req, err := http.NewRequest("GET", c.baseURL+"/orders", nil)
+	var orders []models.Order
+	err := c.circuitBreaker.Execute(func() error {
+		req, err := http.NewRequest("GET", c.baseURL+"/orders", nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)  
+		if err != nil {
+			return fmt.Errorf("failed to send request to order service: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var response struct {
+			Success bool            `json:"success"`
+			Orders  []models.Order  `json:"orders"`
+			Count   int             `json:"count"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			return fmt.Errorf("failed to decode order service response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("order service returned error status: %d", resp.StatusCode)
+		}
+
+		orders = response.Orders
+		c.logger.WithField("count", response.Count).Info("Retrieved orders from order service")
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		c.logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+			"circuit_breaker_state": c.circuitBreaker.State().String(),
+		}).Error("Failed to get orders from order service")
+		return nil, err
 	}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request to order service: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var response struct {
-		Success bool            `json:"success"`
-		Orders  []models.Order  `json:"orders"`
-		Count   int             `json:"count"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("failed to decode order service response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("order service returned error status: %d", resp.StatusCode)
-	}
-
-	c.logger.WithField("count", response.Count).Info("Retrieved orders from order service")
-	return response.Orders, nil
+	return orders, nil
 }
 
 func (c *OrderServiceClient) GetOrder(orderID string) (*models.Order, error) {
 	c.logger.WithField("order_id", orderID).Info("Fetching order from order service")
 	
-	req, err := http.NewRequest("GET", c.baseURL+"/orders/"+orderID, nil)
+	var order *models.Order
+	err := c.circuitBreaker.Execute(func() error {
+		req, err := http.NewRequest("GET", c.baseURL+"/orders/"+orderID, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to send request to order service: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("order not found in order service")
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("order service returned error status: %d", resp.StatusCode)
+		}
+
+		var orderData models.Order
+		if err := json.NewDecoder(resp.Body).Decode(&orderData); err != nil {
+			return fmt.Errorf("failed to decode order service response: %w", err)
+		}
+
+		order = &orderData
+		c.logger.WithField("order_id", orderID).Info("Retrieved order from order service")
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		c.logger.WithFields(logrus.Fields{
+			"order_id": orderID,
+			"error": err.Error(),
+			"circuit_breaker_state": c.circuitBreaker.State().String(),
+		}).Error("Failed to get order from order service")
+		return nil, err
 	}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request to order service: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("order not found in order service")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("order service returned error status: %d", resp.StatusCode)
-	}
-
-	var order models.Order
-	if err := json.NewDecoder(resp.Body).Decode(&order); err != nil {
-		return nil, fmt.Errorf("failed to decode order service response: %w", err)
-	}
-
-	c.logger.WithField("order_id", orderID).Info("Retrieved order from order service")
-	return &order, nil
+	return order, nil
 }

--- a/internal/sap/client.go
+++ b/internal/sap/client.go
@@ -7,124 +7,178 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/jogardn/strangler-demo/internal/circuitbreaker"
 	"github.com/jogardn/strangler-demo/pkg/models"
 	"github.com/sirupsen/logrus"
 )
 
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
-	logger     *logrus.Logger
+	baseURL        string
+	httpClient     *http.Client
+	logger         *logrus.Logger
+	circuitBreaker *circuitbreaker.CircuitBreaker
 }
 
-func NewClient(baseURL string, logger *logrus.Logger) *Client {
+func NewClient(baseURL string, logger *logrus.Logger, cbManager *circuitbreaker.Manager) *Client {
+	cb := cbManager.GetOrCreate("sap", circuitbreaker.Config{
+		MaxFailures: 3,
+		Timeout:     10 * time.Second,
+		MaxRequests: 2,
+	})
+	
 	return &Client{
 		baseURL: baseURL,
 		httpClient: &http.Client{
 			Timeout: 30 * time.Second,
 		},
-		logger: logger,
+		logger:         logger,
+		circuitBreaker: cb,
 	}
 }
 
 func (c *Client) CreateOrder(order *models.Order) (*models.OrderResponse, error) {
 	c.logger.WithField("order_id", order.ID).Info("Sending order to SAP")
 	
-	jsonData, err := json.Marshal(order)
+	var orderResp *models.OrderResponse
+	err := c.circuitBreaker.Execute(func() error {
+		jsonData, err := json.Marshal(order)
+		if err != nil {
+			return fmt.Errorf("failed to marshal order: %w", err)
+		}
+
+		req, err := http.NewRequest("POST", c.baseURL+"/orders", bytes.NewBuffer(jsonData))
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to send request to SAP: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var respData models.OrderResponse
+		if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+			return fmt.Errorf("failed to decode SAP response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+			return fmt.Errorf("SAP returned error status: %d", resp.StatusCode)
+		}
+
+		orderResp = &respData
+		
+		c.logger.WithFields(logrus.Fields{
+			"order_id": order.ID,
+			"status":   resp.StatusCode,
+			"success":  respData.Success,
+		}).Info("Received response from SAP")
+
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal order: %w", err)
+		c.logger.WithFields(logrus.Fields{
+			"order_id": order.ID,
+			"error": err.Error(),
+			"circuit_breaker_state": c.circuitBreaker.State().String(),
+		}).Error("Failed to create order in SAP")
+		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", c.baseURL+"/orders", bytes.NewBuffer(jsonData))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request to SAP: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var orderResp models.OrderResponse
-	if err := json.NewDecoder(resp.Body).Decode(&orderResp); err != nil {
-		return nil, fmt.Errorf("failed to decode SAP response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("SAP returned error status: %d", resp.StatusCode)
-	}
-
-	c.logger.WithFields(logrus.Fields{
-		"order_id": order.ID,
-		"status":   resp.StatusCode,
-		"success":  orderResp.Success,
-	}).Info("Received response from SAP")
-
-	return &orderResp, nil
+	return orderResp, nil
 }
 
 func (c *Client) GetOrders() ([]models.Order, error) {
 	c.logger.Info("Fetching orders from SAP")
 	
-	req, err := http.NewRequest("GET", c.baseURL+"/orders", nil)
+	var orders []models.Order
+	err := c.circuitBreaker.Execute(func() error {
+		req, err := http.NewRequest("GET", c.baseURL+"/orders", nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to send request to SAP: %w", err)
+		}
+		defer resp.Body.Close()
+
+		var response struct {
+			Success bool            `json:"success"`
+			Orders  []models.Order  `json:"orders"`
+			Count   int             `json:"count"`
+		}
+
+		if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			return fmt.Errorf("failed to decode SAP response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("SAP returned error status: %d", resp.StatusCode)
+		}
+
+		orders = response.Orders
+		c.logger.WithField("count", response.Count).Info("Retrieved orders from SAP")
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		c.logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+			"circuit_breaker_state": c.circuitBreaker.State().String(),
+		}).Error("Failed to get orders from SAP")
+		return nil, err
 	}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request to SAP: %w", err)
-	}
-	defer resp.Body.Close()
-
-	var response struct {
-		Success bool            `json:"success"`
-		Orders  []models.Order  `json:"orders"`
-		Count   int             `json:"count"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		return nil, fmt.Errorf("failed to decode SAP response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("SAP returned error status: %d", resp.StatusCode)
-	}
-
-	c.logger.WithField("count", response.Count).Info("Retrieved orders from SAP")
-	return response.Orders, nil
+	return orders, nil
 }
 
 func (c *Client) GetOrder(orderID string) (*models.Order, error) {
 	c.logger.WithField("order_id", orderID).Info("Fetching order from SAP")
 	
-	req, err := http.NewRequest("GET", c.baseURL+"/orders/"+orderID, nil)
+	var order *models.Order
+	err := c.circuitBreaker.Execute(func() error {
+		req, err := http.NewRequest("GET", c.baseURL+"/orders/"+orderID, nil)
+		if err != nil {
+			return fmt.Errorf("failed to create request: %w", err)
+		}
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("failed to send request to SAP: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("order not found in SAP")
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("SAP returned error status: %d", resp.StatusCode)
+		}
+
+		var orderData models.Order
+		if err := json.NewDecoder(resp.Body).Decode(&orderData); err != nil {
+			return fmt.Errorf("failed to decode SAP response: %w", err)
+		}
+
+		order = &orderData
+		c.logger.WithField("order_id", orderID).Info("Retrieved order from SAP")
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		c.logger.WithFields(logrus.Fields{
+			"order_id": orderID,
+			"error": err.Error(),
+			"circuit_breaker_state": c.circuitBreaker.State().String(),
+		}).Error("Failed to get order from SAP")
+		return nil, err
 	}
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to send request to SAP: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("order not found in SAP")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("SAP returned error status: %d", resp.StatusCode)
-	}
-
-	var order models.Order
-	if err := json.NewDecoder(resp.Body).Decode(&order); err != nil {
-		return nil, fmt.Errorf("failed to decode SAP response: %w", err)
-	}
-
-	c.logger.WithField("order_id", orderID).Info("Retrieved order from SAP")
-	return &order, nil
+	return order, nil
 }

--- a/scripts/test-circuit-breaker.sh
+++ b/scripts/test-circuit-breaker.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Test script for circuit breaker functionality
+# This script demonstrates how the circuit breaker protects against failing services
+
+PROXY_URL="http://localhost:8080"
+METRICS_URL="$PROXY_URL/metrics/circuit-breakers"
+RESET_URL="$PROXY_URL/circuit-breakers/reset"
+
+echo "=== Circuit Breaker Test Script ==="
+echo "Proxy URL: $PROXY_URL"
+echo ""
+
+# Function to check circuit breaker metrics
+check_metrics() {
+    echo "--- Circuit Breaker Metrics ---"
+    curl -s "$METRICS_URL" | jq '.circuit_breakers' 2>/dev/null || curl -s "$METRICS_URL"
+    echo ""
+}
+
+# Function to create an order (will fail if SAP is down)
+create_order() {
+    local order_id="test-order-$(date +%s)"
+    echo "Creating order: $order_id"
+    
+    curl -s -X POST "$PROXY_URL/orders" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"id\": \"$order_id\",
+            \"customer_id\": \"customer-123\",
+            \"items\": [{
+                \"product_id\": \"widget-1\",
+                \"quantity\": 2,
+                \"unit_price\": 10.00,
+                \"specifications\": {\"color\": \"blue\"}
+            }],
+            \"total_amount\": 20.00,
+            \"delivery_date\": \"$(date -d '+7 days' '+%Y-%m-%dT%H:%M:%SZ')\",
+            \"status\": \"pending\"
+        }" | jq '.' 2>/dev/null || echo "Request failed or returned non-JSON response"
+    echo ""
+}
+
+# Check initial metrics
+echo "1. Initial circuit breaker state:"
+check_metrics
+
+# Create a few orders to test normal operation
+echo "2. Testing normal operation (creating 3 orders):"
+for i in {1..3}; do
+    echo "  Order $i:"
+    create_order
+    sleep 1
+done
+
+# Check metrics after normal operation
+echo "3. Circuit breaker state after normal operation:"
+check_metrics
+
+# Stop SAP service to trigger circuit breaker (in real scenario)
+echo "4. To test circuit breaker failure protection:"
+echo "   - Stop the SAP service: docker-compose stop sap-mock"
+echo "   - Then run this script again to see circuit breaker protection"
+echo "   - Restart SAP service: docker-compose start sap-mock"
+echo ""
+
+echo "5. Other useful commands:"
+echo "   - View metrics: curl $METRICS_URL | jq"
+echo "   - Reset all circuit breakers: curl -X POST $RESET_URL"
+echo "   - Reset specific circuit breaker: curl -X POST $RESET_URL/sap"
+echo "   - Check health: curl $PROXY_URL/api/health/all | jq"
+echo ""
+
+echo "=== Test completed ==="


### PR DESCRIPTION
This pull request introduces a comprehensive circuit breaker implementation to enhance service resilience and prevent cascading failures. Key changes include adding circuit breaker endpoints, integrating circuit breaker logic into the SAP and Order Service clients, updating documentation, and providing testing scripts.

### Circuit Breaker Implementation

#### Code Integration:
* [`cmd/proxy/main.go`](diffhunk://#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52aR9-R14): Integrated circuit breaker manager and configuration for SAP and Order Service clients. Added endpoints for circuit breaker metrics and reset operations. [[1]](diffhunk://#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52aR9-R14) [[2]](diffhunk://#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52aL28-R41) [[3]](diffhunk://#diff-f9921666ad44650aaaa7dd561fbac69ad3ad20f5ed4b7c4dd0c986f403c6a52aR61-R63)

#### Documentation Updates:
* [`API.md`](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R288-R378): Documented new endpoints for retrieving circuit breaker metrics and resetting circuit breakers. Included example curl commands for testing. [[1]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R288-R378) [[2]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R605-R620) [[3]](diffhunk://#diff-b161966f7254af9c9c5382e859495c69622843e4602a6bb4208e08134e660121R639-R643)
* [`CIRCUIT-BREAKER.md`](diffhunk://#diff-25239ac1e21790f32dfa47117c337a113c8a1f67b0dfd68ee6f3847a15f55241R1-R293): Added detailed documentation on circuit breaker implementation, states, configuration, monitoring, and testing.
* `CLAUDE.md` and `README.md`: Updated project status and architecture to include circuit breaker resilience. Added testing instructions and benefits of the circuit breaker pattern. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L3-R5) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L34-R38) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R245-R316) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R16) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L84-R86) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R135-R137) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R179-R186)