### PR TITLE
chore: update claude.yml workflow permissions and allowed tools

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -34,13 +34,19 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           timeout_minutes: "60"
           max_turns: "20"
           allowed_tools: |
+            gh
             Bash(go test ./...)
             Bash(go mod tidy)
             Bash(go build ./...)
             Bash(go fmt ./...)
             Bash(go vet ./...)
+            View
+            GlobTool
+            GrepTool
+            Write
             Edit
             Replace


### PR DESCRIPTION
- Changed permissions for contents from read to write.
- Added github_token to the workflow inputs.
- Expanded the list of allowed tools for the Claude action to include 'View', 'GlobTool', 'GrepTool', and 'Write'.

These updates enhance the functionality and capabilities of the Claude workflow.