### PR TITLE
Claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,7 +20,7 @@ jobs:
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -34,13 +34,19 @@ jobs:
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           timeout_minutes: "60"
           max_turns: "20"
           allowed_tools: |
+            gh
             Bash(go test ./...)
             Bash(go mod tidy)
             Bash(go build ./...)
             Bash(go fmt ./...)
             Bash(go vet ./...)
+            View
+            GlobTool
+            GrepTool
+            Write
             Edit
             Replace

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,10 +14,13 @@ on:
 jobs:
   claude-code-action:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      (github.actor == 'jgardner04' || github.actor == 'trusted-collaborator') &&
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This pull request updates the `.github/workflows/claude.yml` file to enhance its functionality and security. The changes include refining the conditions for triggering the workflow, adjusting permissions for GitHub actions, and expanding the list of allowed tools.

### Workflow Trigger Refinements:
* Added conditions to restrict workflow execution to specific GitHub actors (`jgardner04` and `trusted-collaborator`) and grouped existing event-based conditions for clarity.

### Permissions Adjustment:
* Changed the `contents` permission from `read` to `write` to enable modifications to repository content during workflow execution.

### Toolset Expansion:
* Added `github_token` as an input parameter and expanded the list of allowed tools with new entries (`gh`, `View`, `GlobTool`, `GrepTool`, `Write`) to provide more capabilities for the workflow.