### PR TITLE
Jgardner04 issue13

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -42,6 +42,9 @@ jobs:
           max_turns: "20"
           allowed_tools: |
             gh
+            Bash(gh auth status)
+            Bash(gh issue create *)
+            Bash(gh repo view)
             Bash(go test ./...)
             Bash(go mod tidy)
             Bash(go build ./...)

--- a/internal/circuitbreaker/circuit_breaker.go
+++ b/internal/circuitbreaker/circuit_breaker.go
@@ -283,6 +283,10 @@ func New(config Config, logger *logrus.Logger) *CircuitBreaker {
 }
 
 func (cb *CircuitBreaker) Execute(fn func() error) error {
+	return cb.ExecuteContext(context.Background(), fn)
+}
+
+func (cb *CircuitBreaker) ExecuteContext(ctx context.Context, fn func() error) error {
 	// Pre-execution check with lock
 	cb.mutex.Lock()
 
@@ -319,27 +323,31 @@ func (cb *CircuitBreaker) Execute(fn func() error) error {
 	cb.mutex.Unlock()
 
 	// Execute function concurrently and wait for result via channel
-	resultChan := make(chan error, 1)
+	done := make(chan error, 1)
 	go func() {
-		resultChan <- fn()
+		done <- fn()
 	}()
 
-	// Wait for execution to complete
-	err := <-resultChan
+	// Wait for execution to complete with context support
+	select {
+	case err := <-done:
+		// Function completed, update circuit breaker state
+		cb.mutex.Lock()
+		defer cb.mutex.Unlock()
 
-	// Post-execution processing with lock
-	cb.mutex.Lock()
-	defer cb.mutex.Unlock()
-
-	if err != nil {
-		cb.onFailure()
-		cb.totalFailures++
+		if err != nil {
+			cb.onFailure()
+			cb.totalFailures++
+		} else {
+			cb.onSuccess()
+			cb.totalSuccesses++
+		}
 		return err
+	case <-ctx.Done():
+		// Context cancelled/timed out
+		// Don't count context cancellation as circuit breaker failure
+		return ctx.Err()
 	}
-
-	cb.onSuccess()
-	cb.totalSuccesses++
-	return nil
 }
 
 func (cb *CircuitBreaker) onSuccess() {


### PR DESCRIPTION
This pull request introduces enhancements to the circuit breaker implementation and updates to the workflow configuration. The most significant changes include adding context support to the `Execute` method in the circuit breaker, improving its concurrency handling, and expanding the allowed tools in the workflow file.

### Circuit breaker enhancements:

* **Added context support to `Execute` method**: Introduced a new method `ExecuteContext` that accepts a `context.Context` parameter, allowing for cancellation or timeout during execution. Updated the `Execute` method to delegate to `ExecuteContext`. (`internal/circuitbreaker/circuit_breaker.go`, [internal/circuitbreaker/circuit_breaker.goR286-R289](diffhunk://#diff-906e140055867623001a4b32dafb8c74d8895f8c76364d96443fbad39813c2edR286-R289))
* **Improved concurrency handling**: Replaced `resultChan` with `done` channel and added a `select` statement for context-aware execution. This ensures proper handling of context cancellation or timeout without counting it as a failure. (`internal/circuitbreaker/circuit_breaker.go`, [internal/circuitbreaker/circuit_breaker.goL322-R350](diffhunk://#diff-906e140055867623001a4b32dafb8c74d8895f8c76364d96443fbad39813c2edL322-R350))

### Workflow configuration updates:

* **Expanded allowed tools**: Added new Bash commands (`gh auth status`, `gh issue create *`, and `gh repo view`) to the list of allowed tools in the GitHub Actions workflow file (`.github/workflows/claude.yml`). This enhances the automation capabilities of the workflow. (`.github/workflows/claude.yml`, [.github/workflows/claude.ymlR45-R47](diffhunk://#diff-53fec9c265fdba82268df5cd90315b8da57cce43d8e20efbf5c0bdcd1de1342eR45-R47))

closes #13 