### PR TITLE
fix: reduce HTTP timeouts for Order Service and SAP clients

### DIFF
--- a/internal/orders/client.go
+++ b/internal/orders/client.go
@@ -27,7 +27,7 @@ func NewOrderServiceClient(baseURL string, logger *logrus.Logger, cbManager *cir
 	// HTTP timeout should be shorter than circuit breaker timeout for proper coordination
 	// Order Service is a modern microservice with faster expected response times
 	// Default: 15 seconds (matches circuit breaker timeout for proper coordination)
-	httpTimeout := getHTTPTimeout("ORDER_SERVICE_HTTP_TIMEOUT_SECONDS", "15", logger)
+	httpTimeout := getHTTPTimeout("ORDER_SERVICE_HTTP_TIMEOUT_SECONDS", "12", logger)
 
 	return &OrderServiceClient{
 		baseURL: baseURL,

--- a/internal/sap/client.go
+++ b/internal/sap/client.go
@@ -27,7 +27,7 @@ func NewClient(baseURL string, logger *logrus.Logger, cbManager *circuitbreaker.
 	// HTTP timeout should be shorter than circuit breaker timeout for proper coordination
 	// SAP typically has slower response times due to legacy system complexity
 	// Default: 10 seconds (vs 15 seconds for modern Order Service)
-	httpTimeout := getHTTPTimeout("SAP_HTTP_TIMEOUT_SECONDS", "10", logger)
+	httpTimeout := getHTTPTimeout("SAP_HTTP_TIMEOUT_SECONDS", "8", logger)
 
 	return &Client{
 		baseURL: baseURL,


### PR DESCRIPTION
Updated the HTTP timeout settings for both the Order Service and SAP clients to improve responsiveness. The timeout for the Order Service has been changed from 15 seconds to 12 seconds, and for the SAP client, it has been adjusted from 10 seconds to 8 seconds. These changes aim to enhance service coordination and performance.

closes #14 